### PR TITLE
Improve stop pin UI and deduplicate stops

### DIFF
--- a/client/src/features/map/components/Map/Stop/StopPin.tsx
+++ b/client/src/features/map/components/Map/Stop/StopPin.tsx
@@ -1,7 +1,6 @@
 import LocationOnIcon from "@mui/icons-material/LocationOn";
-import { IconButton, Tooltip } from "@mui/material";
-import { blue, red } from "@mui/material/colors";
-import React, { useState } from "react";
+import { Box } from "@mui/material";
+import React from "react";
 
 export interface StopPinProps {
   readonly stopName: string;
@@ -15,27 +14,63 @@ export const StopPin: React.FunctionComponent<StopPinProps> = ({
   stopName,
   highlighted,
 }: StopPinProps) => {
-  const [open, setOpen] = useState(false);
-  // Consider showing stop name when zoom is below 12
   return (
-    <Tooltip
-      onClose={() => {
-        setOpen(false);
+    <Box
+      onClick={onClick}
+      sx={{
+        position: "relative",
+        cursor: onClick ? "pointer" : "default",
+        // Center the badge - it will be the anchor point
+        width: 24,
+        height: 24,
       }}
-      onOpen={() => {
-        setOpen(true);
-      }}
-      open={highlighted || open}
-      placement={"left"}
-      title={stopName}
     >
-      <IconButton onClick={onClick} size={"small"}>
+      {/* Circular badge similar to Google Maps - this is the anchor point */}
+      <Box
+        sx={{
+          width: 24,
+          height: 24,
+          borderRadius: "50%",
+          backgroundColor: highlighted ? "#EA4335" : "#1A73E8",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
+          border: "2px solid white",
+          transition: "all 0.2s ease",
+          "&:hover": {
+            transform: "scale(1.1)",
+            boxShadow: "0 3px 8px rgba(0,0,0,0.4)",
+          },
+        }}
+      >
         <LocationOnIcon
-          fontSize={"small"}
-          style={{ color: highlighted ? red[500] : blue[500] }}
-          sx={{ fontSize: highlighted ? 36 : undefined }}
+          sx={{
+            fontSize: 14,
+            color: "white",
+          }}
         />
-      </IconButton>
-    </Tooltip>
+      </Box>
+
+      {/* Stop name text - absolutely positioned to the right of the badge */}
+      <Box
+        sx={{
+          position: "absolute",
+          left: 28,
+          top: "50%",
+          transform: "translateY(-50%)",
+          fontSize: 13,
+          fontWeight: 500,
+          color: "#202124",
+          backgroundColor: "rgba(255, 255, 255, 0.92)",
+          padding: "2px 6px",
+          borderRadius: "2px",
+          boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {stopName}
+      </Box>
+    </Box>
   );
 };

--- a/client/src/features/map/hooks/Map/useStops.tsx
+++ b/client/src/features/map/hooks/Map/useStops.tsx
@@ -24,6 +24,12 @@ export const useStops = () => {
       : [];
   const currentStopArray = currentStop !== undefined ? [currentStop] : [];
   const stops = [...routeStops, ...searchStops, ...currentStopArray] as Stop[];
+  // Remove duplicate stops based on stopId
+  const uniqueStopsMap: Record<string, Stop> = {};
+  stops.forEach((stop) => {
+    uniqueStopsMap[stop.stopId] = stop;
+  });
+  const uniqueStops = Object.values(uniqueStopsMap);
 
-  return { stops };
+  return { stops: uniqueStops };
 };

--- a/client/src/features/search/components/SearchPanel/SearchPanel.test.tsx
+++ b/client/src/features/search/components/SearchPanel/SearchPanel.test.tsx
@@ -34,11 +34,7 @@ describe("SearchPanel", () => {
   it("renders", () => {
     render(
       <BrowserRouter>
-        <SearchPanel
-          onMenuClick={vi.fn()}
-          setRoute={vi.fn()}
-          setStop={vi.fn()}
-        />
+        <SearchPanel onMenuClick={vi.fn()} />
       </BrowserRouter>,
       { wrapper }
     );

--- a/client/src/shared/hooks/UseCurrentStop.test.tsx
+++ b/client/src/shared/hooks/UseCurrentStop.test.tsx
@@ -1,0 +1,163 @@
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
+import { GeometryType, Stop } from "shared/types/interface.d";
+import { describe, expect, test, vi, beforeEach } from "vitest";
+import { useCurrentStop } from "./UseCurrentStop";
+
+const mocks = vi.hoisted(() => {
+  return {
+    mockNavigate: vi.fn(),
+    mockUseParams: vi.fn(),
+    mockUseDataFromRouteLoader: vi.fn(),
+    mockAddToRecentSearches: vi.fn(),
+    mockUseViewStatePathname: vi.fn(),
+    mockUseAtom: vi.fn(),
+  };
+});
+
+vi.mock("react-router-dom", async () => {
+  const actual = (await vi.importActual("react-router-dom")) as object;
+  return {
+    ...actual,
+    useNavigate: () => mocks.mockNavigate,
+    useParams: () => mocks.mockUseParams(),
+  };
+});
+
+vi.mock("app/Router", () => ({
+  useDataFromRouteLoader: () => mocks.mockUseDataFromRouteLoader(),
+}));
+
+vi.mock("shared/hooks/UseRecentSearches", () => ({
+  useRecentSearches: () => ({
+    addToRecentSearches: mocks.mockAddToRecentSearches,
+  }),
+}));
+
+vi.mock("shared/hooks/UseViewStatePathname", () => ({
+  useViewStatePathname: () => mocks.mockUseViewStatePathname(),
+}));
+
+vi.mock("jotai", async () => {
+  const actual = (await vi.importActual("jotai")) as object;
+  return {
+    ...actual,
+    useAtom: () => mocks.mockUseAtom(),
+  };
+});
+
+describe("useCurrentStop", () => {
+  const mockStop: Stop = {
+    stopId: "123",
+    stopName: "Test Stop",
+    stopLoc: {
+      type: GeometryType.Point,
+      coordinates: [-97.456, 30.123],
+    },
+  };
+
+  const mockSetCurrentStop = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mockUseParams.mockReturnValue({
+      routeId: undefined,
+      directionId: undefined,
+    });
+    mocks.mockUseDataFromRouteLoader.mockReturnValue(undefined);
+    mocks.mockUseViewStatePathname.mockReturnValue({
+      viewStatePathname: "/@30.123,-97.456,13z",
+    });
+    mocks.mockUseAtom.mockReturnValue([undefined, mockSetCurrentStop]);
+  });
+
+  test("should return currentStop from atom", () => {
+    mocks.mockUseAtom.mockReturnValue([mockStop, mockSetCurrentStop]);
+
+    const { result } = renderHook(() => useCurrentStop(), {
+      wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+    });
+
+    expect(result.current.currentStop).toEqual(mockStop);
+  });
+
+  test("should sync stop from loader with atom", () => {
+    mocks.mockUseDataFromRouteLoader.mockReturnValue({ stop: mockStop });
+
+    renderHook(() => useCurrentStop(), {
+      wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+    });
+
+    expect(mockSetCurrentStop).toHaveBeenCalledWith(mockStop);
+  });
+
+  test("should navigate to stop page when setStop is called", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/@30.123,-97.456,13z",
+      },
+      writable: true,
+    });
+
+    const { result } = renderHook(() => useCurrentStop(), {
+      wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+    });
+
+    act(() => {
+      result.current.setStop(mockStop);
+    });
+
+    expect(mocks.mockAddToRecentSearches).toHaveBeenCalledWith(mockStop);
+    expect(mockSetCurrentStop).toHaveBeenCalledWith(mockStop);
+    expect(mocks.mockNavigate).toHaveBeenCalledWith(
+      "/@30.123,-97.456,13z/stop/123"
+    );
+  });
+
+  test("should navigate to stop page with route context when on route page", () => {
+    Object.defineProperty(window, "location", {
+      value: {
+        pathname: "/@30.123,-97.456,13z/route/318",
+      },
+      writable: true,
+    });
+
+    mocks.mockUseParams.mockReturnValue({
+      routeId: "318",
+      directionId: "1",
+    });
+
+    const { result } = renderHook(() => useCurrentStop(), {
+      wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+    });
+
+    act(() => {
+      result.current.setStop(mockStop);
+    });
+
+    expect(mocks.mockAddToRecentSearches).toHaveBeenCalledWith(mockStop);
+    expect(mockSetCurrentStop).toHaveBeenCalledWith(mockStop);
+    expect(mocks.mockNavigate).toHaveBeenCalledWith(
+      "/@30.123,-97.456,13z/stop/123?routeId=318&directionId=1"
+    );
+  });
+
+  test("should not navigate when stopId is undefined", () => {
+    const invalidStop = {
+      ...mockStop,
+      stopId: (undefined as unknown) as string,
+    };
+
+    const { result } = renderHook(() => useCurrentStop(), {
+      wrapper: ({ children }) => <BrowserRouter>{children}</BrowserRouter>,
+    });
+
+    act(() => {
+      result.current.setStop(invalidStop as Stop);
+    });
+
+    expect(mocks.mockAddToRecentSearches).not.toHaveBeenCalled();
+    expect(mocks.mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/gtfs_service.py
+++ b/server/services/gtfs_service.py
@@ -84,7 +84,7 @@ class GTFSService:
                     peewee.fn.ST_SetSRID(peewee.fn.ST_MakePoint(lon, lat), 4326),
                 )
             )
-            .limit(100)
+            .limit(20)
         )
 
     @staticmethod


### PR DESCRIPTION
Refactored StopPin to display a styled badge and stop name, removed tooltip and icon button for a cleaner UI. Updated useStops hook to deduplicate stops by stopId. Adjusted SearchPanel test props. Added comprehensive tests for useCurrentStop. Reduced GTFSService stop query limit from 100 to 20 for performance.