### PR TITLE
Update GraphQL schema and config path

### DIFF
--- a/client/graphql.config.yml
+++ b/client/graphql.config.yml
@@ -1,4 +1,4 @@
-schema: src/schemas/schema.graphql
+schema: src/shared/api/schemas/schema.graphql
 extensions:
   endpoints:
     Default GraphQL Endpoint:

--- a/client/src/shared/api/schemas/schema.graphql
+++ b/client/src/shared/api/schemas/schema.graphql
@@ -75,11 +75,9 @@ type Query {
 
 type Route {
     "Agency for the specified route."
-    agencyId: Int
+    agencyId: String
     "Route color designation that matches public facing material."
     routeColor: String
-    "Description of a route that provides useful, quality information."
-    routeDesc: String
     "Identifies a route."
     routeId: String!
     "Full name of a route."
@@ -130,10 +128,8 @@ type StopTimes {
     pickupType: Int
     shapeDistTraveled: Float
     stop: Stop!
-    stopHeadsign: String
     stopId: String!
     stopSequence: Int!
-    supEstDelay: String
     timepoint: Int
     tripId: String!
 }
@@ -153,6 +149,8 @@ type Trip {
     route: Route!
     "Identifies a route."
     routeId: String!
+    "Identifies the scheduled trip ID from the transit agency."
+    scheduledTripId: String
     "Identifies a set of dates when service is available for one or more routes."
     serviceId: String!
     "Identifies a geospatial shape describing the vehicle travel path for a trip."


### PR DESCRIPTION
Changed the schema path in graphql.config.yml to reflect the new location. Updated types in schema.graphql: agencyId is now a String, removed unused fields from Route and StopTimes, and added scheduledTripId to Trip for improved data accuracy.