### PR TITLE
Add Favorites menu and update related navigation

### DIFF
--- a/client/src/app/Router.tsx
+++ b/client/src/app/Router.tsx
@@ -1,4 +1,5 @@
 import { VehiclePositionsDevPage } from "features/dev/pages/VehiclePositionsDevPage";
+import { FavoritesMenu } from "features/favorites/pages/FavoritesMenu";
 import { routeLoader } from "features/route/pages/route/RouteLoader";
 import { RouteMenu } from "features/route/pages/route/RouteMenu";
 import { RecentSearchesMenu } from "features/search/pages/recent/RecentSearchesMenu";
@@ -51,6 +52,10 @@ export const router = createBrowserRouter(
         <Route
           element={<RecentSearchesMenu />}
           path={"recent-searches/:viewState?"}
+        ></Route>
+        <Route
+          element={<FavoritesMenu />}
+          path={"favorites/:viewState?"}
         ></Route>
         <Route
           id={"stop"}

--- a/client/src/features/favorites/pages/FavoritesMenu.tsx
+++ b/client/src/features/favorites/pages/FavoritesMenu.tsx
@@ -1,0 +1,126 @@
+import BookmarkIcon from "@mui/icons-material/Bookmark";
+import PlaceOutlinedIcon from "@mui/icons-material/PlaceOutlined";
+import RouteIcon from "@mui/icons-material/Route";
+import {
+  Box,
+  Container,
+  Divider,
+  List,
+  ListItem,
+  ListItemButton,
+  Typography,
+} from "@mui/material";
+import {
+  isRoute,
+  isStop,
+} from "features/search/components/SearchPanel/hooks/searchPanelUtils";
+import { useSetAtom } from "jotai";
+import * as React from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { useFavorites } from "shared/components/AddToFavorites/useFavorites";
+import { MenuPanel } from "shared/components/MenuPanel/MenuPanel";
+import { RouteIdDisplay } from "shared/components/RouteIdDisplay/RouteIdDisplay";
+import { useTitle } from "shared/hooks/UseTitle";
+import { useViewStatePathname } from "shared/hooks/UseViewStatePathname";
+import { hoveringStopAtom } from "shared/state/atoms";
+import { Stop } from "shared/types/interface.d";
+
+export const FavoritesMenu = () => {
+  const { favorites } = useFavorites();
+  const { viewStatePathname } = useViewStatePathname();
+  const setHoveringStop = useSetAtom(hoveringStopAtom);
+
+  useTitle("Favorites - Austin Bus Go");
+
+  const favoriteStops = favorites.filter(isStop);
+  const favoriteRoutes = favorites.filter(isRoute);
+  const hasFavorites = favorites.length > 0;
+
+  return (
+    <MenuPanel>
+      <Container sx={{ p: 2 }}>
+        <Box alignItems={"center"} display={"flex"} gap={1}>
+          <BookmarkIcon />
+          <Typography variant={"h6"}>Favorites</Typography>
+        </Box>
+      </Container>
+
+      {!hasFavorites && (
+        <Container sx={{ p: 2 }}>
+          <Typography>Start adding favorites!</Typography>
+          <Typography color={"gray"} fontSize={14}>
+            You can add routes or stops to favorites by clicking the bookmark
+            button on their detail pages.
+          </Typography>
+        </Container>
+      )}
+
+      {hasFavorites && (
+        <List>
+          {favoriteStops.map((stop) => (
+            <React.Fragment key={`favorite-stop-${stop.stopId}`}>
+              <ListItem disablePadding={true}>
+                <ListItemButton
+                  component={RouterLink}
+                  onMouseEnter={() => {
+                    setHoveringStop(stop as Stop);
+                  }}
+                  onMouseLeave={() => {
+                    setHoveringStop(undefined);
+                  }}
+                  sx={{ py: 2 }}
+                  to={`/stop/${stop.stopId}${viewStatePathname}`}
+                >
+                  <Box display={"flex"} flexDirection={"column"} gap={1}>
+                    <Box display={"flex"} gap={1}>
+                      <PlaceOutlinedIcon />
+                      <Typography fontWeight={"bold"}>
+                        {stop.stopName}
+                      </Typography>
+                    </Box>
+
+                    <Typography color={"gray"} fontSize={14}>
+                      {"Stop Code: "}
+                      {stop.stopId}
+                    </Typography>
+
+                    <Box display={"flex"} flexWrap={"wrap"} gap={1}>
+                      {stop?.routes?.map((route) => (
+                        <RouteIdDisplay
+                          key={route.routeId}
+                          routeColor={route.routeColor}
+                          routeId={route.routeId}
+                        />
+                      ))}
+                    </Box>
+                  </Box>
+                </ListItemButton>
+              </ListItem>
+              <Divider />
+            </React.Fragment>
+          ))}
+          {favoriteRoutes.map((route) => (
+            <React.Fragment key={`favorite-route-${route.routeId}`}>
+              <ListItem disablePadding={true}>
+                <ListItemButton
+                  component={RouterLink}
+                  to={`/route/${route.routeId}/direction/0${viewStatePathname}`}
+                >
+                  <Box display={"flex"} gap={1}>
+                    <RouteIcon />
+                    <RouteIdDisplay
+                      routeColor={route.routeColor}
+                      routeId={route.routeId}
+                    />
+                    {route.routeLongName}
+                  </Box>
+                </ListItemButton>
+              </ListItem>
+              <Divider />
+            </React.Fragment>
+          ))}
+        </List>
+      )}
+    </MenuPanel>
+  );
+};

--- a/client/src/features/map/components/Map/AssistiveChips/AssistiveChips.tsx
+++ b/client/src/features/map/components/Map/AssistiveChips/AssistiveChips.tsx
@@ -101,7 +101,7 @@ export const AssistiveChips: React.FC<AssistiveChipsProps> = () => {
             textTransform: "none",
             px: "12px",
           }}
-          to={`/search/Favorites${viewStatePathname}`}
+          to={`/favorites${viewStatePathname}`}
         >
           <BookmarkIcon sx={{ fontSize: 18, mr: "4px" }} />
           <Typography fontSize={14} fontWeight={500}>

--- a/client/src/features/search/components/SearchPanel/SearchAutocomplete.tsx
+++ b/client/src/features/search/components/SearchPanel/SearchAutocomplete.tsx
@@ -1,7 +1,7 @@
 import { Autocomplete, createFilterOptions } from "@mui/material";
 import * as React from "react";
 import { useRef, useState } from "react";
-import { useNavigation, useParams } from "react-router-dom";
+import { useLocation, useNavigation, useParams } from "react-router-dom";
 import { useCurrentRoute } from "shared/hooks/UseCurrentRoute";
 import { useCurrentStop } from "shared/hooks/UseCurrentStop";
 
@@ -36,9 +36,16 @@ export const SearchAutocomplete: React.FunctionComponent<SearchAutocompleteProps
   const { currentRoute } = useCurrentRoute();
   const { currentStop } = useCurrentStop();
   const { searchTerm } = useParams();
+  const location = useLocation();
 
   const navigation = useNavigation();
   const externalLoading = navigation.location !== undefined;
+
+  // Check if we're on the favorites or recent searches page
+  const isOnFavoritesPage = location.pathname.startsWith("/favorites");
+  const isOnRecentSearchesPage = location.pathname.startsWith(
+    "/recent-searches"
+  );
 
   // Custom hooks for managing search state
   const {
@@ -69,6 +76,8 @@ export const SearchAutocomplete: React.FunctionComponent<SearchAutocompleteProps
     setValue,
     onOpenChange,
     search,
+    isOnFavoritesPage,
+    isOnRecentSearchesPage,
   });
 
   // Handle selection changes
@@ -84,10 +93,15 @@ export const SearchAutocomplete: React.FunctionComponent<SearchAutocompleteProps
 
   // Clear selection and reset state
   const handleClearSelection = () => {
-    handleClear();
-    setInputString("");
-    setValue(null);
-    onOpenChange(true);
+    // If on favorites or recent searches page, navigate to base path
+    if (isOnFavoritesPage || isOnRecentSearchesPage) {
+      handleClear();
+    } else {
+      handleClear();
+      setInputString("");
+      setValue(null);
+      onOpenChange(true);
+    }
   };
 
   // Handle search page navigation

--- a/client/src/features/search/components/SearchPanel/hooks/useSearchSync.ts
+++ b/client/src/features/search/components/SearchPanel/hooks/useSearchSync.ts
@@ -16,6 +16,8 @@ interface UseSearchSyncParams {
   setValue: (value: SearchOption | null) => void;
   onOpenChange: (open: boolean) => void;
   search: (value: string) => void;
+  isOnFavoritesPage?: boolean;
+  isOnRecentSearchesPage?: boolean;
 }
 
 /**
@@ -31,9 +33,19 @@ export const useSearchSync = ({
   setValue,
   onOpenChange,
   search,
+  isOnFavoritesPage,
+  isOnRecentSearchesPage,
 }: UseSearchSyncParams) => {
   useEffect(() => {
-    if (searchTerm) {
+    if (isOnFavoritesPage) {
+      setInputString("Favorites");
+      setValue(null);
+      onOpenChange(false);
+    } else if (isOnRecentSearchesPage) {
+      setInputString("Recent Searches");
+      setValue(null);
+      onOpenChange(false);
+    } else if (searchTerm) {
       setInputString(searchTerm);
       setValue({
         type: SearchType.recent,
@@ -65,5 +77,5 @@ export const useSearchSync = ({
     }
     // setInputString and search are memoized in useSearchInput, so they're stable
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchTerm, stop, route]);
+  }, [searchTerm, stop, route, isOnFavoritesPage, isOnRecentSearchesPage]);
 };

--- a/client/src/features/search/pages/search/SearchLoader.tsx
+++ b/client/src/features/search/pages/search/SearchLoader.tsx
@@ -1,9 +1,5 @@
 import { LoaderFunctionArgs } from "@remix-run/router/utils";
 import { queryClient } from "app/QueryClient";
-import {
-  isRoute,
-  isStop,
-} from "features/search/components/SearchPanel/hooks/searchPanelUtils";
 import { redirect } from "react-router-dom";
 import {
   NearByStopsQuery,
@@ -19,8 +15,6 @@ import {
   useSearchQuery,
 } from "shared/api/schemas/Search.generated";
 import { useViewStatePathname } from "shared/hooks/UseViewStatePathname";
-import { FavoritesType } from "shared/state/atoms";
-import { Route, Stop } from "shared/types/interface.d";
 
 const searchQuery = (id: SearchQueryVariables) => ({
   queryKey: useSearchQuery.getKey(id),
@@ -61,33 +55,6 @@ export const searchLoader = async ({ params }: LoaderFunctionArgs) => {
       search: {
         stops: nearbyStopsData.nearByStops,
         routes: [],
-      },
-    };
-  } else if (
-    searchTerm.toLocaleLowerCase() === "Favorites".toLocaleLowerCase()
-  ) {
-    const favoritesRawString = localStorage.getItem("favorites");
-    if (!favoritesRawString) {
-      return {
-        search: {
-          stops: [],
-          routes: [],
-        },
-      };
-    }
-
-    const favorites = JSON.parse(favoritesRawString) as FavoritesType[];
-    const favoriteStops = favorites.filter((favorite) =>
-      isStop(favorite)
-    ) as Stop[];
-    const favoriteRoutes = favorites.filter((favorite) =>
-      isRoute(favorite)
-    ) as Route[];
-
-    return {
-      search: {
-        stops: favoriteStops,
-        routes: favoriteRoutes,
       },
     };
   }


### PR DESCRIPTION
Introduces a dedicated FavoritesMenu page and route, updates navigation and assistive chips to link to the new favorites path, and refactors search autocomplete and sync logic to handle favorites and recent searches pages. Removes favorites-specific logic from the search loader, centralizing favorites display in the new menu.