### PR TITLE
perf(ci): speed up client test run

### DIFF
--- a/.github/workflows/onPR.yml
+++ b/.github/workflows/onPR.yml
@@ -36,9 +36,15 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: client/package-lock.json
+      - name: Cache Vite transform cache
+        uses: actions/cache@v3
+        with:
+          path: client/node_modules/.vite
+          key: vite-${{ runner.os }}-${{ hashFiles('client/package-lock.json') }}
+          restore-keys: vite-${{ runner.os }}-
       - name: Install dependencies
         working-directory: ./client
         run: npm ci

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -26,6 +26,7 @@ export default defineConfig(() => {
       globals: true,
       environment: "jsdom",
       setupFiles: "./src/setupTests.js",
+      include: ["src/**/*.test.{ts,tsx}"],
     },
   };
 });


### PR DESCRIPTION
## Summary

- Add explicit `include` pattern in vitest config to scope test discovery to `src/**/*.test.{ts,tsx}`, avoiding scanning all 130 source files
- Upgrade CI Node.js from 18 to 22 for faster ESM/transform performance
- Cache Vite transform cache (`node_modules/.vite`) in CI to skip re-transforms on warm runs

## Test plan

- [x] Verify all 72 client tests pass on CI
- [ ] Confirm CI client-testing job runs faster than before (~75s baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)