### PR TITLE
chore: remove unused dependencies numpy and testcontainers

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -13,7 +13,6 @@ alembic==1.14.0
 # GTFS
 gtfs-realtime-bindings==1.0.0
 shapely==2.0.1
-numpy<2
 pytz==2025.2
 
 # Production server (Gunicorn + UvicornWorker)
@@ -26,4 +25,3 @@ pytest-mock==3.12.0
 pytest-cov==4.1.0
 pytest-asyncio==0.24.0
 coverage==7.2.3
-testcontainers==3.7.1


### PR DESCRIPTION
## Summary

- Remove `numpy` — no imports found anywhere in the codebase
- Remove `testcontainers` — leftover from the Peewee ORM era, not used after the SQLAlchemy async migration

## Test plan

- [ ] CI backend tests pass without these dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)