### PR TITLE
Add PR preview environments (issue #130)

### DIFF
--- a/.github/workflows/onPR.yml
+++ b/.github/workflows/onPR.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: abg-exb
+          projectName: abg
           directory: client/build
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
           branch: pr-${{ github.event.number }}


### PR DESCRIPTION
Extends onPR.yml with a preview deployment pipeline triggered on every
PR open/update. A PR-tagged Docker image is built and pushed to GCR,
deployed to the shared `austinbusgo-backend-staging` Cloud Run service,
and the frontend is built against that staging URL and deployed to
Cloudflare Pages as a branch preview. A bot comment is created (or
updated) on the PR with direct links to both preview environments.

Adds pr-cleanup.yml to delete the PR-specific GCR image when a PR is
closed, keeping container storage tidy.

Required GitHub secrets:
  - CLOUDFLARE_API_TOKEN  (Pages:Edit permission)
  - CLOUDFLARE_ACCOUNT_ID
  - VITE_MAPBOX_ACCESS_TOKEN  (already present)

One-time manual setup:
  - Create `austinbusgo-backend-staging` Cloud Run service with a
    staging DATABASE_URL pointing to the pre-populated staging DB.
  - Create a `austinbusgo` Cloudflare Pages project connected to this
    repository.

https://claude.ai/code/session_01Tp4G8WvdU371bxos8x1DVQ