### PR TITLE
feat: cache routes-per-stop at startup to reduce DB load

### DIFF
--- a/server/gql/resolver.py
+++ b/server/gql/resolver.py
@@ -60,6 +60,8 @@ class Resolver:
         max_lon: float,
         limit: int = 20,
     ):
+        context = getattr(info, "context", None)
+        route_counts = getattr(context, "stop_route_counts", None)
         return (
             await self.gtfs_service.get_near_by_stops(
                 min_lat=min_lat,
@@ -67,6 +69,7 @@ class Resolver:
                 max_lat=max_lat,
                 max_lon=max_lon,
                 limit=limit,
+                route_counts=route_counts,
             )
             or []
         )

--- a/server/gql/types/gtfs_types.py
+++ b/server/gql/types/gtfs_types.py
@@ -30,10 +30,12 @@ class Stop:
 
     @strawberry.field
     async def routes(self, info: Info) -> List[Route]:
-        session = info.context.session
+        cache = getattr(info.context, "stop_routes_cache", None)
+        if cache is not None:
+            return cache.get(self.stop_id, [])
         from server.services.gtfs_service import GTFSService
 
-        return await GTFSService(session).get_routes_at_stop(self.stop_id)
+        return await GTFSService(info.context.session).get_routes_at_stop(self.stop_id)
 
 
 @strawberry.type

--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,6 @@
 from contextlib import asynccontextmanager
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.ext.asyncio import AsyncSession
 from strawberry.fastapi import BaseContext, GraphQLRouter
@@ -14,16 +14,27 @@ from server.database import (
 )
 from server.gql.resolver import Resolver
 from server.gql.schema import schema
+from server.services.gtfs_service import GTFSService
 
 
 class GraphQLContext(BaseContext):
-    def __init__(self, session: AsyncSession):
+    def __init__(self, session: AsyncSession, stop_routes_cache: dict | None = None):
         self.session = session
         self.resolver = Resolver(session)
+        self.stop_routes_cache = stop_routes_cache
+        # Pre-derive route counts for use in get_near_by_stops ranking
+        self.stop_route_counts = (
+            {stop_id: len(routes) for stop_id, routes in stop_routes_cache.items()}
+            if stop_routes_cache is not None
+            else None
+        )
 
 
-async def get_context(session: AsyncSession = Depends(get_db)) -> GraphQLContext:
-    return GraphQLContext(session)
+async def get_context(
+    request: Request, session: AsyncSession = Depends(get_db)
+) -> GraphQLContext:
+    cache = getattr(request.app.state, "stop_routes_cache", None)
+    return GraphQLContext(session, cache)
 
 
 @asynccontextmanager
@@ -33,6 +44,9 @@ async def lifespan(app: FastAPI):
     init_database(db_url)
     async with database.AsyncSessionLocal() as session:
         await database_sanity_check(session)
+        app.state.stop_routes_cache = await GTFSService(
+            session
+        ).get_all_routes_at_stops()
     yield
 
 

--- a/server/services/gtfs_service.py
+++ b/server/services/gtfs_service.py
@@ -93,6 +93,30 @@ class GTFSService:
         )
         return [SimpleNamespace(**row._mapping) for row in result]
 
+    async def get_all_routes_at_stops(self) -> dict:
+        """Load all routes per stop into memory. Returns {stop_id: [route, ...]}."""
+        result = await self.session.execute(
+            select(
+                RoutesAtStop.stop_id,
+                Routes.route_id,
+                Routes.agency_id,
+                Routes.route_short_name,
+                Routes.route_long_name,
+                Routes.route_color,
+            ).join(Routes, Routes.route_id == RoutesAtStop.route_id)
+        )
+        cache: dict = {}
+        for row in result:
+            route = SimpleNamespace(
+                route_id=row.route_id,
+                agency_id=row.agency_id,
+                route_short_name=row.route_short_name,
+                route_long_name=row.route_long_name,
+                route_color=row.route_color,
+            )
+            cache.setdefault(row.stop_id, []).append(route)
+        return cache
+
     async def get_near_by_stops(
         self,
         min_lat: float,
@@ -100,20 +124,56 @@ class GTFSService:
         max_lat: float,
         max_lon: float,
         limit: int = 20,
+        route_counts: Optional[dict] = None,
     ) -> List[SimpleNamespace]:
         spatial_filter = (
             "ST_Intersects(stop_loc,"
             " ST_MakeEnvelope(:min_lon, :min_lat, :max_lon, :max_lat, 4326)::geography)"
         )
+        center_lon = (min_lon + max_lon) / 2
+        center_lat = (min_lat + max_lat) / 2
         params = {
             "min_lon": min_lon,
             "min_lat": min_lat,
             "max_lon": max_lon,
             "max_lat": max_lat,
-            "center_lon": (min_lon + max_lon) / 2,
-            "center_lat": (min_lat + max_lat) / 2,
+            "center_lon": center_lon,
+            "center_lat": center_lat,
             "limit": limit,
         }
+
+        if route_counts is not None:
+            # Simplified query: skip the routes_at_stop JOIN and GROUP BY.
+            # Ranking is done in Python using the pre-loaded route_counts cache.
+            sql = f"""
+            SELECT stop_id, stop_code, stop_name,
+                   ST_AsGeoJSON(stop_loc) AS stop_loc,
+                   ST_Distance(
+                       stop_loc::geography,
+                       ST_SetSRID(ST_MakePoint(:center_lon, :center_lat), 4326)::geography
+                   ) AS distance
+            FROM stops
+            WHERE {spatial_filter};
+            """
+            result = await self.session.execute(text(sql), params)
+            scored = []
+            for row in result:
+                count = route_counts.get(row.stop_id, 0)
+                score = (count + 1.0) / (row.distance * 10.0 + 1.0)
+                scored.append(
+                    (
+                        score,
+                        SimpleNamespace(
+                            stop_id=row.stop_id,
+                            stop_code=row.stop_code,
+                            stop_name=row.stop_name,
+                            stop_loc=row.stop_loc,
+                            route_count=count,
+                        ),
+                    )
+                )
+            scored.sort(key=lambda x: x[0], reverse=True)
+            return [s for _, s in scored[:limit]]
 
         sql = f"""
         WITH stops_in_radius AS MATERIALIZED (

--- a/server/tests/test_app.py
+++ b/server/tests/test_app.py
@@ -14,8 +14,11 @@ def make_app(mocker):
     mock_session = MagicMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)
     mock_session.__aexit__ = AsyncMock(return_value=False)
-    mocker.patch("server.main.AsyncSessionLocal", return_value=mock_session)
     mocker.patch("server.database.AsyncSessionLocal", return_value=mock_session)
+    # Mock GTFSService so the startup cache load does not require a real DB
+    mock_gtfs = MagicMock()
+    mock_gtfs.get_all_routes_at_stops = AsyncMock(return_value={})
+    mocker.patch("server.main.GTFSService", return_value=mock_gtfs)
     return create_app()
 
 

--- a/server/tests/test_gtfs_service.py
+++ b/server/tests/test_gtfs_service.py
@@ -178,6 +178,119 @@ async def test_get_near_by_stops_empty():
 
 
 @pytest.mark.asyncio
+async def test_get_near_by_stops_with_route_counts_cache():
+    """When route_counts is provided, uses simplified SQL and ranks in Python."""
+    svc, session = make_service()
+
+    # Two stops: stop_1 has 3 routes and stop_2 has 1 route,
+    # but stop_2 is closer, so ranking depends on combined score.
+    row1 = MagicMock()
+    row1.stop_id = "stop_1"
+    row1.stop_code = None
+    row1.stop_name = "Major Stop"
+    row1.stop_loc = None
+    row1.distance = 500.0  # metres
+
+    row2 = MagicMock()
+    row2.stop_id = "stop_2"
+    row2.stop_code = None
+    row2.stop_name = "Minor Stop"
+    row2.stop_loc = None
+    row2.distance = 100.0  # metres
+
+    result_mock = MagicMock()
+    result_mock.__iter__ = MagicMock(return_value=iter([row1, row2]))
+    session.execute.return_value = result_mock
+
+    route_counts = {"stop_1": 3, "stop_2": 1}
+    result = await svc.get_near_by_stops(
+        min_lat=30.0,
+        min_lon=-98.0,
+        max_lat=31.0,
+        max_lon=-97.0,
+        route_counts=route_counts,
+    )
+
+    session.execute.assert_called_once()
+    assert len(result) == 2
+    # stop_1: score = (3+1)/(500*10+1) = 4/5001 ≈ 0.000799
+    # stop_2: score = (1+1)/(100*10+1) = 2/1001 ≈ 0.001998  → stop_2 ranks first
+    assert result[0].stop_id == "stop_2"
+    assert result[1].stop_id == "stop_1"
+
+
+@pytest.mark.asyncio
+async def test_get_near_by_stops_with_route_counts_cache_respects_limit():
+    svc, session = make_service()
+    rows = []
+    for i in range(5):
+        row = MagicMock()
+        row.stop_id = f"stop_{i}"
+        row.stop_code = None
+        row.stop_name = f"Stop {i}"
+        row.stop_loc = None
+        row.distance = float(i + 1) * 100
+        rows.append(row)
+
+    result_mock = MagicMock()
+    result_mock.__iter__ = MagicMock(return_value=iter(rows))
+    session.execute.return_value = result_mock
+
+    result = await svc.get_near_by_stops(
+        min_lat=30.0,
+        min_lon=-98.0,
+        max_lat=31.0,
+        max_lon=-97.0,
+        limit=3,
+        route_counts={},
+    )
+
+    assert len(result) == 3
+
+
+@pytest.mark.asyncio
+async def test_get_all_routes_at_stops():
+    svc, session = make_service()
+
+    row1 = MagicMock()
+    row1.stop_id = "stop_1"
+    row1.route_id = "1"
+    row1.agency_id = None
+    row1.route_short_name = "1"
+    row1.route_long_name = "Route 1"
+    row1.route_color = "FF0000"
+
+    row2 = MagicMock()
+    row2.stop_id = "stop_1"
+    row2.route_id = "2"
+    row2.agency_id = None
+    row2.route_short_name = "2"
+    row2.route_long_name = "Route 2"
+    row2.route_color = None
+
+    row3 = MagicMock()
+    row3.stop_id = "stop_2"
+    row3.route_id = "1"
+    row3.agency_id = None
+    row3.route_short_name = "1"
+    row3.route_long_name = "Route 1"
+    row3.route_color = "FF0000"
+
+    result_mock = MagicMock()
+    result_mock.__iter__ = MagicMock(return_value=iter([row1, row2, row3]))
+    session.execute.return_value = result_mock
+
+    cache = await svc.get_all_routes_at_stops()
+
+    session.execute.assert_called_once()
+    assert len(cache) == 2
+    assert len(cache["stop_1"]) == 2
+    assert len(cache["stop_2"]) == 1
+    assert cache["stop_1"][0].route_id == "1"
+    assert cache["stop_2"][0].route_id == "1"
+
+
+@pytest.mark.asyncio
 async def test_get_stops_by_route_id():
     svc, session = make_service()
     row = MagicMock()

--- a/server/tests/test_resolver.py
+++ b/server/tests/test_resolver.py
@@ -109,6 +109,7 @@ async def test_resolve_near_by_stops():
         max_lat=31.0,
         max_lon=-97.0,
         limit=20,
+        route_counts=None,
     )
     assert result == stops
 


### PR DESCRIPTION
Load all routes_at_stop data once into an in-memory dict
{stop_id: [route, ...]} during the FastAPI lifespan startup event.
This dict is passed through GraphQLContext and used in two places:

- Stop.routes field resolver: reads from cache instead of issuing a
  per-stop DB query, eliminating the N+1 problem when nearByStops
  returns multiple stops (up to 20 queries → 1 startup query).

- get_near_by_stops: when route_counts are available, runs a simpler
  spatial-only SQL (no LEFT JOIN routes_at_stop + GROUP BY) and ranks
  stops in Python using the cached counts, reducing DB work per request.

The fallback to DB queries is preserved when the cache is absent
(e.g. in tests that don't populate it).

https://claude.ai/code/session_01FYKjCVRD8RMdon7kpfEtmF