### PR TITLE
Optimize GTFS update: skip unchanged feeds and build indexes post-load

### DIFF
--- a/etl/indexes.sql
+++ b/etl/indexes.sql
@@ -1,0 +1,11 @@
+-- Indexes are created after bulk data load for significantly faster COPY performance.
+-- PostgreSQL builds these indexes in bulk, which is much faster than maintaining
+-- them incrementally during row-by-row insertion.
+
+CREATE INDEX SHAPES_shape_id ON shapes(shape_id);
+CREATE INDEX TRIPS_trip_id_route_id ON trips(trip_id, route_id);
+CREATE INDEX TRIPS_trip_id_direction_id ON trips(trip_id, direction_id);
+CREATE INDEX STOP_TIMES_trip_id ON stop_times(trip_id);
+CREATE INDEX STOP_TIMES_trip_id_stop_id ON stop_times(trip_id, stop_id);
+CREATE INDEX ROUTES_AT_STOP_stop_id_route_id ON routes_at_stop(stop_id, route_id);
+CREATE INDEX TRANSFERS_from_stop_id_to_stop_id ON transfers(from_stop_id, to_stop_id);

--- a/etl/load.sh
+++ b/etl/load.sh
@@ -2,6 +2,39 @@
 
 cd "$(dirname "$0")"
 
-psql $DATABASE_URL --file=teardown.sql
-psql $DATABASE_URL --file=schema.sql
-psql $DATABASE_URL --file=load.sql
+# ---------------------------------------------------------------------------
+# Feed version check: skip the expensive reload when the feed hasn't changed.
+# Compares feed_start_date from the freshly-downloaded feed_info.txt against
+# what is currently stored in the database.
+# ---------------------------------------------------------------------------
+CURRENT_FEED_START=$(psql "$DATABASE_URL" -t -c \
+  "SELECT to_char(feed_start_date, 'YYYYMMDD') FROM feed_info LIMIT 1;" \
+  2>/dev/null | tr -d ' \n')
+
+NEW_FEED_START=$(python3 - <<'EOF'
+import csv
+with open("capmetro/feed_info.txt") as f:
+    for row in csv.DictReader(f):
+        print(row["feed_start_date"].strip())
+        break
+EOF
+)
+
+if [ -n "$CURRENT_FEED_START" ] && [ "$CURRENT_FEED_START" = "$NEW_FEED_START" ]; then
+  echo "Feed start date unchanged ($CURRENT_FEED_START), skipping database reload."
+  exit 0
+fi
+
+echo "Loading new GTFS feed (feed_start_date: $NEW_FEED_START, was: ${CURRENT_FEED_START:-none})"
+
+# ---------------------------------------------------------------------------
+# Reload: drop -> create schema (no indexes yet) -> bulk COPY -> create indexes.
+#
+# Indexes are intentionally created AFTER the bulk load.  Building them on an
+# already-populated table is far faster than maintaining them incrementally
+# during each COPY row insertion, especially for the large stop_times table.
+# ---------------------------------------------------------------------------
+psql "$DATABASE_URL" --file=teardown.sql
+psql "$DATABASE_URL" --file=schema.sql
+psql "$DATABASE_URL" --file=load.sql
+psql "$DATABASE_URL" --file=indexes.sql

--- a/etl/schema.sql
+++ b/etl/schema.sql
@@ -132,10 +132,3 @@ JOIN trips ON trips.trip_id = stop_times.trip_id
 JOIN routes ON routes.route_id = trips.route_id
 GROUP BY routes.route_id, stop_times.stop_id;
 
-CREATE INDEX SHAPES_shape_id ON shapes(shape_id);
-CREATE INDEX TRIPS_trip_id_route_id ON trips(trip_id, route_id);
-CREATE INDEX TRIPS_trip_id_direction_id ON trips(trip_id, direction_id);
-CREATE INDEX STOP_TIMES_trip_id ON stop_times(trip_id);
-CREATE INDEX STOP_TIMES_trip_id_stop_id ON stop_times(trip_id, stop_id);
-CREATE INDEX ROUTES_AT_STOP_stop_id_route_id ON routes_at_stop(stop_id, route_id);
-CREATE INDEX TRANSFERS_from_stop_id_to_stop_id ON transfers(from_stop_id, to_stop_id);


### PR DESCRIPTION
Two changes to reduce the time the daily updateGTFS workflow spends on
the database, particularly for the large stop_times table:

1. Feed version check in load.sh: compare feed_start_date from the
   freshly-downloaded feed_info.txt against the value currently stored
   in the database.  When they match the entire teardown/reload is
   skipped.  CapMetro publishes new GTFS feeds roughly weekly, so most
   daily runs will exit immediately.

2. Deferred index creation: all CREATE INDEX statements are moved from
   schema.sql into a new indexes.sql that runs after load.sql.
   PostgreSQL builds indexes in bulk on a fully-populated table much
   faster than maintaining them incrementally during each COPY row
   insertion.  The stop_times table benefits most because it has two
   non-PK indexes and millions of rows.

Load order is now: teardown -> schema (tables + views, no indexes) ->
load (COPY + REFRESH MATERIALIZED VIEW) -> indexes.

https://claude.ai/code/session_019B4EHeqD5ApyEzQtpT7rz4