### PR TITLE
Enrich bus stop info with routes, accessibility, and location

### DIFF
--- a/client/src/features/stop/components/StopRoutes/StopRoutes.tsx
+++ b/client/src/features/stop/components/StopRoutes/StopRoutes.tsx
@@ -1,0 +1,41 @@
+import { Box, Tooltip, Typography } from "@mui/material";
+import * as React from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { StopQuery } from "shared/api/schemas/Stop.generated";
+import { RouteIdDisplay } from "shared/components/RouteIdDisplay/RouteIdDisplay";
+import { useViewStatePathname } from "shared/hooks/UseViewStatePathname";
+
+interface StopRoutesProps {
+  routes: StopQuery["stop"]["routes"];
+}
+
+export const StopRoutes: React.FC<StopRoutesProps> = ({ routes }) => {
+  const { viewStatePathname } = useViewStatePathname();
+
+  if (!routes || routes.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box px={2} py={1}>
+      <Typography color={"text.secondary"} mb={0.5} variant={"caption"}>
+        Routes at this stop
+      </Typography>
+      <Box display={"flex"} flexWrap={"wrap"} gap={1}>
+        {routes.map((route) => (
+          <Tooltip key={route.routeId} title={route.routeLongName}>
+            <RouterLink
+              style={{ textDecoration: "none" }}
+              to={`/route/${route.routeId}/direction/0${viewStatePathname}`}
+            >
+              <RouteIdDisplay
+                routeColor={route.routeColor}
+                routeId={route.routeShortName || route.routeId}
+              />
+            </RouterLink>
+          </Tooltip>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/client/src/features/stop/pages/stop/StopMenu.tsx
+++ b/client/src/features/stop/pages/stop/StopMenu.tsx
@@ -1,8 +1,11 @@
+import AccessibleIcon from "@mui/icons-material/Accessible";
+import NotAccessibleIcon from "@mui/icons-material/NotAccessible";
 import PlaceOutlinedIcon from "@mui/icons-material/PlaceOutlined";
-import { Box, Divider, Typography } from "@mui/material";
+import { Box, Divider, Tooltip, Typography } from "@mui/material";
 import { useDataFromLoader } from "app/Router";
 import { ArrivalTimeList } from "features/stop/components/ArrivalTimeList/ArrivalTimeList";
 import { RoutesSelector } from "features/stop/components/RoutesSelector/RoutesSelector";
+import { StopRoutes } from "features/stop/components/StopRoutes/StopRoutes";
 import { useAtom } from "jotai";
 import * as React from "react";
 import { useEffect } from "react";
@@ -21,6 +24,26 @@ import { stopLoader } from "./StopLoader";
 interface StopMenuProps {
   hideBackButton?: boolean;
 }
+
+const WheelchairBoardingIcon: React.FC<{ wheelchairBoarding?: number | null }> = ({
+  wheelchairBoarding,
+}) => {
+  if (wheelchairBoarding === 1) {
+    return (
+      <Tooltip title={"Wheelchair accessible"}>
+        <AccessibleIcon color={"success"} fontSize={"small"} />
+      </Tooltip>
+    );
+  }
+  if (wheelchairBoarding === 2) {
+    return (
+      <Tooltip title={"Not wheelchair accessible"}>
+        <NotAccessibleIcon color={"disabled"} fontSize={"small"} />
+      </Tooltip>
+    );
+  }
+  return null;
+};
 
 export const StopMenu: React.FC<StopMenuProps> = ({ hideBackButton }) => {
   const [searchParams] = useSearchParams();
@@ -83,6 +106,11 @@ export const StopMenu: React.FC<StopMenuProps> = ({ hideBackButton }) => {
     setSelectedRouteInitialValues(routeIds);
   }, []);
 
+  const intersection =
+    stop.onStreet && stop.atStreet
+      ? `${stop.onStreet} at ${stop.atStreet}`
+      : null;
+
   return (
     <MenuPanel>
       <Box
@@ -111,7 +139,14 @@ export const StopMenu: React.FC<StopMenuProps> = ({ hideBackButton }) => {
             >
               <PlaceOutlinedIcon />
               <Typography variant={"subtitle1"}>{stop.stopName}</Typography>
+              <WheelchairBoardingIcon wheelchairBoarding={stop.wheelchairBoarding} />
             </Box>
+
+            {intersection && (
+              <Typography color={"text.secondary"} textAlign={"center"} variant={"caption"}>
+                {intersection}
+              </Typography>
+            )}
 
             <Typography textAlign={"center"} variant={"subtitle2"}>
               Stop ID: {stop.stopId}
@@ -124,6 +159,9 @@ export const StopMenu: React.FC<StopMenuProps> = ({ hideBackButton }) => {
           <ShareButton />
         </Box>
 
+        <Divider />
+        <StopRoutes routes={stop.routes} />
+
         {!isLoading && arrivalTimes.length > 0 && uniqueRouteIds.length > 1 && (
           <Box
             sx={{
@@ -133,6 +171,9 @@ export const StopMenu: React.FC<StopMenuProps> = ({ hideBackButton }) => {
               pr: 1,
             }}
           >
+            <Typography color={"text.secondary"} mb={0.5} variant={"caption"}>
+              Filter by route
+            </Typography>
             <RoutesSelector
               arrivalTimes={arrivalTimes}
               selectedRouteIds={selectedRouteIds}
@@ -140,6 +181,11 @@ export const StopMenu: React.FC<StopMenuProps> = ({ hideBackButton }) => {
             />
           </Box>
         )}
+      </Box>
+      <Box px={2} pt={1}>
+        <Typography color={"text.secondary"} variant={"caption"}>
+          Upcoming arrivals
+        </Typography>
       </Box>
       <ArrivalTimeList
         arrivalTimes={arrivalTimes}

--- a/client/src/shared/api/schemas/Stop.generated.ts
+++ b/client/src/shared/api/schemas/Stop.generated.ts
@@ -32,11 +32,23 @@ export type StopQuery = {
     stopId: string;
     stopCode?: string | null;
     stopName?: string | null;
+    stopDesc?: string | null;
+    stopUrl?: string | null;
+    wheelchairBoarding?: number | null;
+    onStreet?: string | null;
+    atStreet?: string | null;
     stopLoc?: {
       __typename?: "Point";
       type: Types.GeometryType;
       coordinates: Array<number>;
     } | null;
+    routes: Array<{
+      __typename?: "Route";
+      routeId: string;
+      routeShortName?: string | null;
+      routeLongName: string;
+      routeColor?: string | null;
+    }>;
   };
 };
 
@@ -46,9 +58,20 @@ export const StopDocument = `
     stopId
     stopCode
     stopName
+    stopDesc
+    stopUrl
+    wheelchairBoarding
+    onStreet
+    atStreet
     stopLoc {
       type
       coordinates
+    }
+    routes {
+      routeId
+      routeShortName
+      routeLongName
+      routeColor
     }
   }
 }

--- a/client/src/shared/api/schemas/Stop.tsx
+++ b/client/src/shared/api/schemas/Stop.tsx
@@ -6,9 +6,20 @@ export const STOP_QUERY = gql`
       stopId
       stopCode
       stopName
+      stopDesc
+      stopUrl
+      wheelchairBoarding
+      onStreet
+      atStreet
       stopLoc {
         type
         coordinates
+      }
+      routes {
+        routeId
+        routeShortName
+        routeLongName
+        routeColor
       }
     }
   }

--- a/server/gql/types/gtfs_types.py
+++ b/server/gql/types/gtfs_types.py
@@ -20,6 +20,11 @@ class Stop:
     stop_id: str
     stop_code: Optional[str] = None
     stop_name: Optional[str] = None
+    stop_desc: Optional[str] = None
+    stop_url: Optional[str] = None
+    wheelchair_boarding: Optional[int] = None
+    on_street: Optional[str] = None
+    at_street: Optional[str] = None
 
     @strawberry.field
     def stop_loc(self) -> Optional[Point]:


### PR DESCRIPTION
- Backend: expose wheelchair_boarding, on_street, at_street, stop_desc,
  and stop_url fields on the Stop GraphQL type
- Backend: the existing routes field resolver is now consumed by the client
- Client: update STOP_QUERY and generated types to fetch new stop fields
  and all routes serving the stop
- Client: add StopRoutes component showing route chips (with tooltips for
  long name) that link to each route page
- Client: show wheelchair boarding accessibility icon in the stop header
- Client: display intersection label (on_street at at_street) under the
  stop name for better wayfinding
- Client: add "Upcoming arrivals" section label and "Filter by route" label
  above the route selector for clarity

https://claude.ai/code/session_01JTUsBYhV7PDSEdP7TZ3ScN