### PR TITLE
Show Scheduled/Live label only when arrival time data is present

### DIFF
--- a/client/src/features/route/components/RouteStopsTimeline/RouteStopsTimeline.tsx
+++ b/client/src/features/route/components/RouteStopsTimeline/RouteStopsTimeline.tsx
@@ -195,17 +195,19 @@ export const RouteStopsTimeline: React.FC<StopsTimelineProps> = ({
                   >
                     <Box display={"flex"} flexDirection={"column"}>
                       <Typography fontWeight={600}>{stop.stopName}</Typography>
-                      <Typography
-                        color={
-                          updatedArrivalTime
-                            ? theme.palette.success.light
-                            : theme.palette.grey["500"]
-                        }
-                        fontSize={14}
-                        fontWeight={updatedArrivalTime ? 600 : undefined}
-                      >
-                        {updatedArrivalTime ? "Live" : "Scheduled"}
-                      </Typography>
+                      {at && (
+                        <Typography
+                          color={
+                            updatedArrivalTime
+                              ? theme.palette.success.light
+                              : theme.palette.grey["500"]
+                          }
+                          fontSize={14}
+                          fontWeight={updatedArrivalTime ? 600 : undefined}
+                        >
+                          {updatedArrivalTime ? "Live" : "Scheduled"}
+                        </Typography>
+                      )}
                     </Box>
 
                     {timeDiff !== undefined && at && (


### PR DESCRIPTION
Previously the "Scheduled" label was rendered unconditionally for every
stop on the route timeline, even when no arrival time data was returned
by the earliestArrivalTimesOnRoute query (e.g. stops with no upcoming
service). This caused stops to display "Scheduled" with no time value
on the right side, which was misleading.

The label is now wrapped in an `{at && ...}` guard that mirrors the
existing condition on the time display block. When arrival time data
is available the label and the time both render; when there is no data
for a stop, neither renders.

https://claude.ai/code/session_01FxMuRpntgsdw81mok7SRYU