### PR TITLE
feat: preload nearby stops in root loader before map renders

### DIFF
--- a/client/src/features/map/hooks/UseNearByStops.test.tsx
+++ b/client/src/features/map/hooks/UseNearByStops.test.tsx
@@ -15,6 +15,10 @@ vi.mock("shared/api/schemas/NearByStops.generated", () => ({
   useNearByStopsQuery: mocks.mockUseNearByStopsQuery,
 }));
 
+vi.mock("react-router-dom", () => ({
+  useRouteLoaderData: vi.fn(() => undefined),
+}));
+
 vi.mock("react-map-gl/mapbox", () => ({
   useMap: vi.fn(() => ({
     mapId: {
@@ -70,7 +74,7 @@ describe("useNearByStops", () => {
         maxLon: -97.7,
         limit: 40,
       }),
-      { enabled: false, keepPreviousData: true }
+      expect.objectContaining({ enabled: false, keepPreviousData: true })
     );
   });
 

--- a/client/src/features/map/hooks/UseNearByStops.tsx
+++ b/client/src/features/map/hooks/UseNearByStops.tsx
@@ -1,11 +1,24 @@
 import { ViewState } from "features/map/components/Map";
 import { useMap } from "react-map-gl/mapbox";
+import { useRouteLoaderData } from "react-router-dom";
 import { useNearByStopsQuery } from "shared/api/schemas/NearByStops.generated";
 import { useDebounce } from "shared/hooks/useDebounce";
+import { searchParamsDataLoader } from "shared/loaders/searchParamsDataLoader";
 import { Stop } from "shared/types/interface.d";
+
+type SearchParamsLoaderData = Awaited<
+  ReturnType<typeof searchParamsDataLoader>
+>;
 
 export const useNearByStops = (viewState?: ViewState) => {
   const { mapId: map } = useMap();
+  const loaderData = useRouteLoaderData("searchParams") as
+    | SearchParamsLoaderData
+    | undefined;
+  const preloadedStops =
+    loaderData && "nearByStops" in loaderData
+      ? loaderData.nearByStops
+      : undefined;
 
   const limit = viewState
     ? viewState.zoom <= 11
@@ -42,11 +55,17 @@ export const useNearByStops = (viewState?: ViewState) => {
   const { data, isFetching } = useNearByStopsQuery(debouncedQueryParams, {
     enabled: shouldFetch,
     keepPreviousData: true,
+    placeholderData: preloadedStops
+      ? { nearByStops: preloadedStops }
+      : undefined,
   });
 
   const isLoading = isFetching;
 
-  const nearByStops: Stop[] = shouldFetch ? (data?.nearByStops ?? []) : [];
+  const nearByStops: Stop[] =
+    shouldFetch || preloadedStops
+      ? (data?.nearByStops ?? preloadedStops ?? [])
+      : [];
 
   return {
     isLoading,

--- a/client/src/shared/loaders/searchParamsDataLoader.tsx
+++ b/client/src/shared/loaders/searchParamsDataLoader.tsx
@@ -1,6 +1,10 @@
 import { LoaderFunctionArgs } from "@remix-run/router/utils";
 import { queryClient } from "app/QueryClient";
 import {
+  NearByStopsQuery,
+  useNearByStopsQuery,
+} from "shared/api/schemas/NearByStops.generated";
+import {
   RouteQuery,
   RouteQueryVariables,
   useRouteQuery,
@@ -16,6 +20,10 @@ import {
   VehiclePositionsQueryVariables,
 } from "shared/api/schemas/VehiclePositions.generated";
 import { getDate } from "shared/utils/dateUtils";
+import {
+  computeBoundsFromViewState,
+  parseViewStateFromPathname,
+} from "shared/utils/viewStateUtils";
 
 const routeQuery = (id: RouteQueryVariables) => ({
   queryKey: useRouteQuery.getKey(id),
@@ -37,7 +45,23 @@ export const searchParamsDataLoader = async ({
   const directionId = Number(url.searchParams.get("directionId") || "");
 
   if (routeId === "") {
-    return {};
+    const { latitude, longitude, zoom } = parseViewStateFromPathname(
+      url.pathname
+    );
+    const bounds = computeBoundsFromViewState(
+      latitude,
+      longitude,
+      zoom,
+      window.innerWidth,
+      window.innerHeight
+    );
+    const nearByStopsData = await queryClient.ensureQueryData<NearByStopsQuery>(
+      {
+        queryKey: useNearByStopsQuery.getKey(bounds),
+        queryFn: useNearByStopsQuery.fetcher(bounds),
+      }
+    );
+    return { nearByStops: nearByStopsData?.nearByStops ?? [] };
   }
 
   const routeDataQuery = queryClient.ensureQueryData<RouteQuery>(

--- a/client/src/shared/utils/viewStateUtils.ts
+++ b/client/src/shared/utils/viewStateUtils.ts
@@ -1,0 +1,50 @@
+const DEFAULT_LATITUDE = 30.2672;
+const DEFAULT_LONGITUDE = -97.7431;
+const DEFAULT_ZOOM = 11.5;
+
+export type ViewStateBounds = {
+  minLat: number;
+  maxLat: number;
+  minLon: number;
+  maxLon: number;
+  limit: number;
+};
+
+export function parseViewStateFromPathname(pathname: string): {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+} {
+  const match = pathname.match(/@([-0-9.]+),([-0-9.]+),([0-9.]+)z/);
+  return {
+    latitude: match?.[1] ? Number(match[1]) : DEFAULT_LATITUDE,
+    longitude: match?.[2] ? Number(match[2]) : DEFAULT_LONGITUDE,
+    zoom: match?.[3] ? Number(match[3]) : DEFAULT_ZOOM,
+  };
+}
+
+/**
+ * Computes approximate map bounding box from a view state and viewport size.
+ * Uses Web Mercator math matching Mapbox GL's tile size (512px).
+ */
+export function computeBoundsFromViewState(
+  latitude: number,
+  longitude: number,
+  zoom: number,
+  viewportWidth: number,
+  viewportHeight: number
+): ViewStateBounds {
+  const TILE_SIZE = 512;
+  const lonPerPixel = 360 / (TILE_SIZE * Math.pow(2, zoom));
+  const latPerPixel = lonPerPixel * Math.cos((latitude * Math.PI) / 180);
+
+  const limit = zoom <= 11 ? 40 : zoom <= 14 ? 80 : 100;
+
+  return {
+    minLat: latitude - (viewportHeight / 2) * latPerPixel,
+    maxLat: latitude + (viewportHeight / 2) * latPerPixel,
+    minLon: longitude - (viewportWidth / 2) * lonPerPixel,
+    maxLon: longitude + (viewportWidth / 2) * lonPerPixel,
+    limit,
+  };
+}


### PR DESCRIPTION
Adds a data loader step to the root route that fetches nearby stops
before the page renders, so stop markers appear immediately instead of
waiting for the Mapbox canvas to initialise and fire its own query.

- viewStateUtils.ts: pure functions to parse the view-state from the
  URL pathname and compute a bounding box from lat/lon/zoom + viewport
  dimensions using Web Mercator math (matching Mapbox's 512-px tile size)
- searchParamsDataLoader: when there is no route context, parses the
  view state from the URL and uses window dimensions to compute bounds,
  then calls ensureQueryData for NearByStops and returns the results
- UseNearByStops: reads the preloaded stops from the root loader via
  useRouteLoaderData and passes them as placeholderData so they are
  displayed while the map is still initialising; once the map is ready
  the hook fires its normal bounds-based query and the cache is updated

https://claude.ai/code/session_01CfxRjzp6Kg89tE1pY7cLcV