### PR TITLE
Fetch all-vehicles map layer from GTFS-RT worker instead of backend

### DIFF
--- a/client/src/features/map/hooks/useAllVehiclePositions.test.tsx
+++ b/client/src/features/map/hooks/useAllVehiclePositions.test.tsx
@@ -5,12 +5,12 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { useAllVehiclePositions } from "./useAllVehiclePositions";
 
 const mocks = vi.hoisted(() => ({
-  useRealTimeVehiclePositionsQuery: vi.fn(),
+  useGtfsRtVehiclePositions: vi.fn(),
   useShowAllVehicles: vi.fn(),
 }));
 
-vi.mock("shared/api/schemas/RealTimeVehiclePositions.generated", () => ({
-  useRealTimeVehiclePositionsQuery: mocks.useRealTimeVehiclePositionsQuery,
+vi.mock("shared/hooks/useGtfsRtFrontend", () => ({
+  useGtfsRtVehiclePositions: mocks.useGtfsRtVehiclePositions,
 }));
 
 vi.mock("shared/hooks/UseShowAllVehicles", () => ({
@@ -23,15 +23,11 @@ describe("useAllVehiclePositions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.useShowAllVehicles.mockReturnValue([true]);
-    mocks.useRealTimeVehiclePositionsQuery.mockReturnValue({
-      data: undefined,
-    });
+    mocks.useGtfsRtVehiclePositions.mockReturnValue({ data: undefined });
   });
 
-  test("returns vehicles and filters out nulls", () => {
-    mocks.useRealTimeVehiclePositionsQuery.mockReturnValue({
-      data: { realTimeVehiclePositions: [vehicle, null] },
-    });
+  test("returns vehicles from the GTFS-RT feed", () => {
+    mocks.useGtfsRtVehiclePositions.mockReturnValue({ data: [vehicle] });
 
     const { result } = renderHook(() => useAllVehiclePositions());
 
@@ -40,15 +36,12 @@ describe("useAllVehiclePositions", () => {
 
   test("returns empty array and disables the query when toggled off", () => {
     mocks.useShowAllVehicles.mockReturnValue([false]);
-    mocks.useRealTimeVehiclePositionsQuery.mockReturnValue({
-      data: { realTimeVehiclePositions: [vehicle] },
-    });
+    mocks.useGtfsRtVehiclePositions.mockReturnValue({ data: [vehicle] });
 
     const { result } = renderHook(() => useAllVehiclePositions());
 
     expect(result.current.allVehiclePositions).toEqual([]);
-    expect(mocks.useRealTimeVehiclePositionsQuery).toHaveBeenCalledWith(
-      undefined,
+    expect(mocks.useGtfsRtVehiclePositions).toHaveBeenCalledWith(
       expect.objectContaining({ enabled: false })
     );
   });

--- a/client/src/features/map/hooks/useAllVehiclePositions.tsx
+++ b/client/src/features/map/hooks/useAllVehiclePositions.tsx
@@ -1,30 +1,26 @@
 import { useAtomValue } from "jotai";
-import { useMemo } from "react";
-import { useRealTimeVehiclePositionsQuery } from "shared/api/schemas/RealTimeVehiclePositions.generated";
+import { useGtfsRtVehiclePositions } from "shared/hooks/useGtfsRtFrontend";
 import { useShowAllVehicles } from "shared/hooks/UseShowAllVehicles";
 import { isAutoPollingAtom } from "shared/state/atoms";
 import { VehiclePosition } from "shared/types/interface.d";
 
 const NO_VEHICLES: VehiclePosition[] = [];
 
+/**
+ * All active vehicles, fetched directly from the GTFS-RT feed via the
+ * gtfs-rt-proxy worker — no backend round-trip (the backend's slowest
+ * queries were the real-time ones, dominated by this same upstream call).
+ */
 export const useAllVehiclePositions = () => {
   const [showAllVehicles] = useShowAllVehicles();
   const autoPolling = useAtomValue(isAutoPollingAtom);
 
-  const { data } = useRealTimeVehiclePositionsQuery(undefined, {
+  const { data } = useGtfsRtVehiclePositions({
     enabled: showAllVehicles,
     refetchInterval: autoPolling ? 15000 : false,
   });
 
-  const allVehiclePositions = useMemo(
-    () =>
-      showAllVehicles && data?.realTimeVehiclePositions
-        ? data.realTimeVehiclePositions.filter(
-            (v): v is VehiclePosition => v !== null
-          )
-        : NO_VEHICLES,
-    [showAllVehicles, data]
-  );
+  const allVehiclePositions = showAllVehicles && data ? data : NO_VEHICLES;
 
   return { allVehiclePositions };
 };

--- a/client/src/shared/hooks/useGtfsRtFrontend.ts
+++ b/client/src/shared/hooks/useGtfsRtFrontend.ts
@@ -9,16 +9,22 @@ const REFETCH_INTERVAL_MS = 15_000;
 export const GTFS_RT_VEHICLE_POSITIONS_KEY = "gtfs-rt-vehicle-positions";
 export const GTFS_RT_TRIP_UPDATES_KEY = "gtfs-rt-trip-updates";
 
+interface GtfsRtQueryOptions {
+  enabled?: boolean;
+  refetchInterval?: number | false;
+}
+
 /**
  * Fetches all CapMetro vehicle positions directly from the GTFS-RT feed,
  * without going through the backend server.
  */
-export function useGtfsRtVehiclePositions() {
+export function useGtfsRtVehiclePositions(options: GtfsRtQueryOptions = {}) {
   return useQuery({
     queryKey: [GTFS_RT_VEHICLE_POSITIONS_KEY],
     queryFn: fetchVehiclePositions,
     refetchInterval: REFETCH_INTERVAL_MS,
     retry: 1,
+    ...options,
   });
 }
 

--- a/client/src/shared/services/gtfsRtFrontend.ts
+++ b/client/src/shared/services/gtfsRtFrontend.ts
@@ -21,15 +21,15 @@ import {
   VehicleStopStatus,
 } from "shared/types/interface.d";
 
-const PROXY_BASE = import.meta.env.VITE_GTFS_RT_PROXY_URL as string | undefined;
+// Deployed worker; override with VITE_GTFS_RT_PROXY_URL (e.g. a local
+// `wrangler dev` instance on http://localhost:8787).
+const DEFAULT_PROXY_URL = "https://gtfs-rt-proxy.gges5110.workers.dev";
+
+const PROXY_BASE =
+  (import.meta.env.VITE_GTFS_RT_PROXY_URL as string | undefined) ||
+  DEFAULT_PROXY_URL;
 
 function feedUrl(path: "/vehicle-positions" | "/trip-updates"): string {
-  if (!PROXY_BASE) {
-    throw new Error(
-      "VITE_GTFS_RT_PROXY_URL is not set. The GTFS-RT feeds require the " +
-        "CORS proxy worker — see workers/gtfs-rt-proxy/README.md."
-    );
-  }
   return `${PROXY_BASE.replace(/\/$/, "")}${path}`;
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #160: promotes the frontend GTFS-RT feed from the dev-page POC into the real app. The "Show all buses" map layer (`useAllVehiclePositions`) now fetches vehicle positions from the gtfs-rt-proxy Cloudflare Worker instead of the backend `realTimeVehiclePositions` GraphQL query.

- Eliminates the backend round-trip for the slowest query class from the February profiling (real-time queries at 400–600ms, dominated by the same upstream feed call the worker now makes once per 15s for all clients)
- `VITE_GTFS_RT_PROXY_URL` now defaults to the deployed worker URL, so local dev and preview builds work with no configuration (env var remains as an override, e.g. for `wrangler dev`)
- `useGtfsRtVehiclePositions` accepts `enabled`/`refetchInterval` options so the map layer keeps its existing toggle + auto-polling behavior
- The mapped feed statuses are the same strings as the GraphQL `VehicleStopStatus` enum, so the vehicle layer works unchanged

The route-specific vehicle layer (`useVehiclePositions`) still uses the backend, since it filters by direction which needs schedule data.

## Test plan
- [x] `npm test` — 180/180 passing; lint clean; production build succeeds
- [x] Verified in Chrome with the local backend fully stopped (all GraphQL calls 503): the map still renders every live vehicle from a single worker request, with correct routes, statuses, and bearings
- [x] Toggle off `?buses=1` → query disabled, no worker requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2