### PR TITLE
Invalidate GraphQL edge cache after nightly GTFS load

### DIFF
--- a/.github/workflows/updateGTFS.yml
+++ b/.github/workflows/updateGTFS.yml
@@ -40,3 +40,23 @@ jobs:
         run: python main.py
         env:
           DATABASE_URL: ${{ secrets.DBURI }}
+
+  invalidate-edge-cache:
+    needs: [upload]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Redeploy graphql-edge-cache with a fresh cache version
+        working-directory: workers/graphql-edge-cache
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        # Rotating CACHE_VERSION orphans all cached GraphQL responses so
+        # static entries never outlive the GTFS data they were built from
+        run: |
+          npm ci
+          npx wrangler deploy --var CACHE_VERSION:gtfs-${{ github.run_id }}

--- a/workers/graphql-edge-cache/README.md
+++ b/workers/graphql-edge-cache/README.md
@@ -14,8 +14,11 @@ TTL:
 GraphQL error responses (200 + `errors`) are never cached. Every response
 carries `X-Edge-Cache: HIT | MISS | BYPASS`.
 
-After a GTFS data reload, bump `CACHE_VERSION` in `src/index.ts` and
-redeploy to drop stale static entries before their TTL expires.
+`CACHE_VERSION` is part of every cache key. The `updateGTFS.yml` workflow
+redeploys this worker with a fresh value (`--var CACHE_VERSION:gtfs-<run id>`)
+after each nightly data load, so static entries never outlive the GTFS data
+they came from. To invalidate manually: `npx wrangler deploy --var
+CACHE_VERSION:<anything new>`.
 
 ## Develop
 

--- a/workers/graphql-edge-cache/src/index.ts
+++ b/workers/graphql-edge-cache/src/index.ts
@@ -18,15 +18,20 @@
 
 interface Env {
   UPSTREAM_GRAPHQL_URL: string;
+  /**
+   * Part of every cache key; changing it orphans all cached entries.
+   * The updateGTFS workflow redeploys with a fresh value after each data
+   * load so static entries don't outlive the GTFS data they came from.
+   */
+  CACHE_VERSION?: string;
 }
 
 /**
  * Per-operation TTLs in seconds.
  *
  * 15s tier: resolvers that read the GTFS-RT feed (matches its cadence).
- * 6h tier: static GTFS data that only changes when the feed is reloaded.
- *
- * Bump CACHE_VERSION after a GTFS reload to drop all static entries early.
+ * 6h tier: static GTFS data that only changes when the feed is reloaded
+ * (the updateGTFS workflow rotates CACHE_VERSION after each load).
  */
 const TTL_SECONDS: Record<string, number> = {
   // Real-time (GTFS-RT backed)
@@ -50,8 +55,6 @@ const TTL_SECONDS: Record<string, number> = {
   Trip: 21600,
   TripIdsForRoute: 21600,
 };
-
-const CACHE_VERSION = "v1";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -136,7 +139,7 @@ export default {
     // identity (covers variables and the query text itself)
     const cacheKey = new Request(
       new URL(
-        `/__gql-cache/${CACHE_VERSION}/${name}/${await sha256Hex(bodyText)}`,
+        `/__gql-cache/${env.CACHE_VERSION ?? "v1"}/${name}/${await sha256Hex(bodyText)}`,
         request.url
       ).toString()
     );

--- a/workers/graphql-edge-cache/wrangler.toml
+++ b/workers/graphql-edge-cache/wrangler.toml
@@ -4,3 +4,5 @@ compatibility_date = "2026-07-01"
 
 [vars]
 UPSTREAM_GRAPHQL_URL = "https://austinbusgo-backend-761140212463.us-central1.run.app/graphql"
+# Rotated by the updateGTFS workflow (deploy --var) after each data load
+CACHE_VERSION = "v1"


### PR DESCRIPTION
## Summary
Automates the cache-invalidation step for the graphql-edge-cache worker:

- `CACHE_VERSION` becomes a wrangler `[vars]` entry (read from `env`) instead of a source constant
- `updateGTFS.yml` gains an `invalidate-edge-cache` job that runs after the nightly ETL and redeploys the worker with `--var CACHE_VERSION:gtfs-<run id>`, orphaning all cached GraphQL responses so static entries (6h TTL) never serve data from the previous GTFS load

Uses the existing `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` secrets. Note: the token was originally created for Pages deploys — if the new job fails with an auth error, the token needs the **Workers Scripts: Edit** permission added in the Cloudflare dashboard.

## Test plan
- [x] Worker type-checks; deployed manually with the env-based version and verified serving
- [x] Workflow YAML validates
- [ ] After merge: trigger `updateGTFS` via workflow_dispatch and confirm the invalidate job deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2