### PR TITLE
Declutter stop dots with Mapbox's native collision engine

### DIFF
--- a/client/src/features/map/components/Map.test.tsx
+++ b/client/src/features/map/components/Map.test.tsx
@@ -39,8 +39,7 @@ vi.mock("react-map-gl/mapbox", () => ({
 }));
 
 vi.mock("./Stop/StopLayer", () => ({
-  STOP_CIRCLES_LAYER_ID: "stop-circles",
-  STOP_LABELS_LAYER_ID: "stop-labels",
+  STOPS_LAYER_ID: "stops",
   StopLayer: (props: Record<string, unknown>) => {
     mocks.stopLayerProps(props);
     return <div data-testid={"stop-layer"} />;
@@ -127,7 +126,7 @@ describe("Map", () => {
 
     expect(mocks.mapProps).toHaveBeenCalledWith(
       expect.objectContaining({
-        interactiveLayerIds: ["stop-circles", "stop-labels", "vehicle-circles"],
+        interactiveLayerIds: ["stops", "vehicle-circles"],
       })
     );
   });

--- a/client/src/features/map/components/Map.tsx
+++ b/client/src/features/map/components/Map.tsx
@@ -17,11 +17,7 @@ import { useCurrentRoute } from "shared/hooks/UseCurrentRoute";
 import { useCurrentStop } from "shared/hooks/UseCurrentStop";
 import { useViewStatePathname } from "shared/hooks/UseViewStatePathname";
 
-import {
-  STOP_CIRCLES_LAYER_ID,
-  STOP_LABELS_LAYER_ID,
-  StopLayer,
-} from "./Stop/StopLayer";
+import { STOPS_LAYER_ID, StopLayer } from "./Stop/StopLayer";
 import { VEHICLE_CIRCLES_LAYER_ID, VehicleLayer } from "./Vehicle/VehicleLayer";
 
 export type ViewState = {
@@ -80,11 +76,7 @@ export const Map: React.FunctionComponent = () => {
       id={"mapId"}
       {...viewState}
       cursor={cursor}
-      interactiveLayerIds={[
-        STOP_CIRCLES_LAYER_ID,
-        STOP_LABELS_LAYER_ID,
-        VEHICLE_CIRCLES_LAYER_ID,
-      ]}
+      interactiveLayerIds={[STOPS_LAYER_ID, VEHICLE_CIRCLES_LAYER_ID]}
       mapStyle={
         darkMode
           ? "mapbox://styles/mapbox/dark-v11"

--- a/client/src/features/map/components/Stop/StopLayer.test.tsx
+++ b/client/src/features/map/components/Stop/StopLayer.test.tsx
@@ -10,7 +10,10 @@ const mocks = vi.hoisted(() => {
   const map = {
     on: vi.fn(),
     off: vi.fn(),
-    getZoom: vi.fn(() => 12),
+    once: vi.fn(),
+    isStyleLoaded: vi.fn(() => true),
+    hasImage: vi.fn(() => true),
+    addImage: vi.fn(),
     getSource: vi.fn(() => ({})),
     setFeatureState: vi.fn(),
   };
@@ -80,21 +83,19 @@ describe("StopLayer", () => {
     mocks.isMobile.mockReturnValue(false);
   });
 
-  test("registers click and hover handlers on both stop layers (desktop)", () => {
+  test("registers click and hover handlers on the stops layer (desktop)", () => {
     renderStopLayer();
 
-    for (const layerId of ["stop-circles", "stop-labels"]) {
-      expect(getLayerHandler("click", layerId)).toBeDefined();
-      expect(getLayerHandler("mouseenter", layerId)).toBeDefined();
-      expect(getLayerHandler("mouseleave", layerId)).toBeDefined();
-    }
+    expect(getLayerHandler("click", "stops")).toBeDefined();
+    expect(getLayerHandler("mouseenter", "stops")).toBeDefined();
+    expect(getLayerHandler("mouseleave", "stops")).toBeDefined();
   });
 
   test("desktop click selects the stop", () => {
     renderStopLayer();
 
     act(() => {
-      getLayerHandler("click", "stop-circles")(featureEvent("s1"));
+      getLayerHandler("click", "stops")(featureEvent("s1"));
     });
 
     expect(mocks.setStop).toHaveBeenCalledWith(stop);
@@ -104,7 +105,7 @@ describe("StopLayer", () => {
     renderStopLayer();
 
     act(() => {
-      getLayerHandler("mouseenter", "stop-circles")(featureEvent("s1"));
+      getLayerHandler("mouseenter", "stops")(featureEvent("s1"));
     });
 
     expect(screen.getByTestId("stop-popup-content")).toHaveTextContent(
@@ -116,7 +117,7 @@ describe("StopLayer", () => {
     renderStopLayer();
 
     act(() => {
-      getLayerHandler("click", "stop-circles")(featureEvent("unknown"));
+      getLayerHandler("click", "stops")(featureEvent("unknown"));
     });
 
     expect(mocks.setStop).not.toHaveBeenCalled();
@@ -127,7 +128,7 @@ describe("StopLayer", () => {
     renderStopLayer();
 
     act(() => {
-      getLayerHandler("click", "stop-circles")(featureEvent("s1"));
+      getLayerHandler("click", "stops")(featureEvent("s1"));
     });
 
     expect(mocks.setStop).not.toHaveBeenCalled();
@@ -140,7 +141,7 @@ describe("StopLayer", () => {
     mocks.isMobile.mockReturnValue(true);
     renderStopLayer();
 
-    expect(getLayerHandler("mouseenter", "stop-circles")).toBeUndefined();
-    expect(getLayerHandler("click", "stop-circles")).toBeDefined();
+    expect(getLayerHandler("mouseenter", "stops")).toBeUndefined();
+    expect(getLayerHandler("click", "stops")).toBeDefined();
   });
 });

--- a/client/src/features/map/components/Stop/StopLayer.tsx
+++ b/client/src/features/map/components/Stop/StopLayer.tsx
@@ -7,11 +7,12 @@ import {
   LayerMouseEvent,
   useLayerEvents,
 } from "features/map/hooks/useLayerEvents";
+import { GeneratedImage, useMapImage } from "features/map/hooks/useMapImage";
 import { toPointFeatureCollection } from "features/map/utils/geojson";
 import { useAtom, useSetAtom } from "jotai";
 import * as React from "react";
-import { FC, useCallback, useEffect, useMemo, useState } from "react";
-import { Layer, Source, useMap } from "react-map-gl/mapbox";
+import { FC, useCallback, useMemo } from "react";
+import { Layer, Source } from "react-map-gl/mapbox";
 import { useCurrentStop } from "shared/hooks/UseCurrentStop";
 import {
   hoveringStopAtom,
@@ -23,49 +24,38 @@ import { Stop } from "shared/types/interface.d";
 import { StopPeekSheet } from "./StopPeekSheet";
 import { StopPopupContent } from "./StopPopupContent";
 
-export const STOP_CIRCLES_LAYER_ID = "stop-circles";
-export const STOP_LABELS_LAYER_ID = "stop-labels";
-const STOP_LAYER_IDS = [STOP_CIRCLES_LAYER_ID, STOP_LABELS_LAYER_ID];
+export const STOPS_LAYER_ID = "stops";
+const STOP_LAYER_IDS = [STOPS_LAYER_ID];
 const STOPS_SOURCE_ID = "stops-source";
+const STOP_DOT_IMAGE_ID = "stop-dot";
 
 /**
- * Returns the cell size in degrees for the label grid at a given zoom level.
- * Halves with each zoom step so the number of visible grid cells stays roughly
- * constant as the user zooms in. Clamped to [0.005°, 1°].
- *   zoom 6  → ~0.25° (~28 km)
- *   zoom 10 → ~0.015° (~1.7 km)
- *   zoom 14 → ~0.001° → clamped to 0.005° (~0.5 km)
+ * SDF sprite for the stop dot. Icons (unlike circle layers) participate in
+ * Mapbox's native collision engine, which is what declutters the ~2,300
+ * stops at low zoom. Encoding the circle as a signed distance field lets
+ * the style recolor it per-feature (icon-color supports feature-state,
+ * which layout-time icon switching does not) and draw the white ring via
+ * icon-halo-*.
  */
-function labelGridCellDeg(zoom: number): number {
-  return Math.min(1, Math.max(0.005, Math.pow(2, 4 - zoom)));
-}
+const DOT_SPRITE_SIZE = 64;
+const DOT_SPRITE_RADIUS = 20;
+const DOT_SDF_SPREAD = 8;
 
-/**
- * Returns the set of stopIds that are the highest-priority stop in their
- * grid cell. Priority is determined by route count (more routes = wins).
- * Ties are broken by stopId for stable output.
- */
-function buildLabelGridWinners(stops: Stop[], zoom: number): Set<string> {
-  const cellDeg = labelGridCellDeg(zoom);
-  const cellBest = new Map<string, { stopId: string; priority: number }>();
-
-  for (const stop of stops) {
-    const coords = stop.stopLoc?.coordinates;
-    if (!coords) continue;
-    const [lon, lat] = coords;
-    const cellKey = `${Math.floor(lat / cellDeg)},${Math.floor(lon / cellDeg)}`;
-    const priority = Math.max(1, 10 - (stop.routes?.length ?? 0));
-    const existing = cellBest.get(cellKey);
-    if (
-      !existing ||
-      priority < existing.priority ||
-      (priority === existing.priority && stop.stopId < existing.stopId)
-    ) {
-      cellBest.set(cellKey, { stopId: stop.stopId, priority });
+function createStopDotImage(): GeneratedImage {
+  const size = DOT_SPRITE_SIZE;
+  const data = new Uint8ClampedArray(size * size * 4);
+  const center = size / 2;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const distance =
+        Math.hypot(x - center + 0.5, y - center + 0.5) - DOT_SPRITE_RADIUS;
+      // Mapbox's SDF shader draws the shape where alpha ≈ 0.75+; the
+      // falloff below that leaves room for the halo ring
+      const alpha = Math.max(0, Math.min(1, 0.75 - distance / DOT_SDF_SPREAD));
+      data[(y * size + x) * 4 + 3] = Math.round(alpha * 255);
     }
   }
-
-  return new Set([...cellBest.values()].map((b) => b.stopId));
+  return { width: size, height: size, data };
 }
 
 interface StopLayerProps {
@@ -81,7 +71,6 @@ export const StopLayer: FC<StopLayerProps> = ({
   darkMode = false,
   disableLod = false,
 }) => {
-  const { mapId: map } = useMap();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [hoveringStop, setHoveringStop] = useAtom(hoveringStopAtom);
@@ -96,6 +85,8 @@ export const StopLayer: FC<StopLayerProps> = ({
   );
   const { scheduleClose, cancelClose } = useHoverClose(closeHoverPopup);
 
+  useMapImage(STOP_DOT_IMAGE_ID, createStopDotImage, true);
+
   const stopsById = useMemo(() => {
     const m = new Map<string, Stop>();
     for (const stop of stops) {
@@ -104,39 +95,25 @@ export const StopLayer: FC<StopLayerProps> = ({
     return m;
   }, [stops]);
 
-  // Track integer zoom so the grid only recomputes on whole-zoom-level changes.
-  const [zoom, setZoom] = useState<number>(() =>
-    Math.floor(map?.getZoom() ?? 10)
+  const stopsGeoJSON = useMemo(
+    () =>
+      toPointFeatureCollection(
+        stops,
+        (stop) => stop.stopLoc?.coordinates,
+        (stop) => ({
+          stopCode: stop.stopCode ?? "",
+          stopId: stop.stopId,
+          stopName: stop.stopName ?? "",
+          // More routes = lower sort key number = placed first = wins
+          // collision against less-connected stops
+          priority: Math.max(1, 10 - (stop.routes?.length ?? 0)),
+        })
+      ),
+    [stops]
   );
-  useEffect(() => {
-    if (!map) return;
-    const onZoom = () => setZoom(Math.floor(map.getZoom()));
-    map.on("zoom", onZoom);
-    return () => {
-      map.off("zoom", onZoom);
-    };
-  }, [map]);
-
-  const stopsGeoJSON = useMemo(() => {
-    const gridWinners = buildLabelGridWinners(stops, zoom);
-    return toPointFeatureCollection(
-      stops,
-      (stop) => stop.stopLoc?.coordinates,
-      (stop) => ({
-        stopCode: stop.stopCode ?? "",
-        stopId: stop.stopId,
-        stopName: stop.stopName ?? "",
-        // More routes = lower sort key number = placed first = wins collision
-        priority: Math.max(1, 10 - (stop.routes?.length ?? 0)),
-        // 1 if this stop is the highest-priority in its label-grid cell;
-        // used to show one representative stop per region at all zoom levels.
-        gridRank: gridWinners.has(stop.stopId) ? 1 : 0,
-      })
-    );
-  }, [stops, zoom]);
 
   // Sync hoveringStop atom with Mapbox feature state so sidebar hover
-  // highlights the corresponding circle on the map.
+  // highlights the corresponding dot on the map.
   useFeatureHoverState(STOPS_SOURCE_ID, hoveringStop?.stopId);
 
   const handleMouseEnter = useCallback(
@@ -191,13 +168,45 @@ export const StopLayer: FC<StopLayerProps> = ({
       promoteId={"stopId"}
       type={"geojson"}
     >
-      {/* Circle layer for stop pin dots — WebGL rendered, no DOM overhead.
-          Below zoom 13 only the label-grid winner per cell is shown,
-          ensuring geographic spread. At zoom 13+ all stops appear. */}
+      {/* Single symbol layer for dots + labels. The native collision engine
+          declutters both: dots thin out at low zoom (icon-padding widens the
+          collision box), and labels drop before dots do (text-optional).
+          On route pages (disableLod) every stop must stay visible, so icons
+          are allowed to overlap. */}
       <Layer
-        id={STOP_CIRCLES_LAYER_ID}
+        id={STOPS_LAYER_ID}
+        layout={{
+          "icon-allow-overlap": disableLod,
+          "icon-image": STOP_DOT_IMAGE_ID,
+          // Wider collision box at low zoom = fewer, better-spaced dots
+          "icon-padding": ["interpolate", ["linear"], ["zoom"], 8, 10, 13, 2],
+          "icon-size": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            6,
+            0.15,
+            11,
+            0.2,
+            14,
+            0.35,
+            18,
+            0.5,
+          ],
+          "symbol-sort-key": ["get", "priority"],
+          // Labels only at zoom 10+; collision then hides overlaps
+          "text-field": ["step", ["zoom"], "", 10, ["get", "stopName"]],
+          "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+          // Drop the label under collision pressure but keep the dot
+          "text-optional": true,
+          "text-radial-offset": 0.8,
+          "text-size": 12,
+          // Let labels slide to whichever side fits — places more labels
+          // in dense areas than a fixed anchor
+          "text-variable-anchor": ["right", "left", "top", "bottom"],
+        }}
         paint={{
-          "circle-color": [
+          "icon-color": [
             "case",
             ["==", ["get", "stopId"], selectedStopId],
             "#EA4335",
@@ -205,71 +214,16 @@ export const StopLayer: FC<StopLayerProps> = ({
             "#EA4335",
             "#1A73E8",
           ],
-          "circle-opacity": disableLod
-            ? 1
-            : [
-                "step",
-                ["zoom"],
-                ["case", ["==", ["get", "gridRank"], 1], 1, 0],
-                13,
-                1,
-              ],
-          "circle-radius": [
+          "icon-halo-color": "#ffffff",
+          "icon-halo-width": [
             "interpolate",
             ["linear"],
             ["zoom"],
             6,
-            3,
+            0.5,
             11,
-            4,
-            14,
-            7,
-            18,
-            10,
-          ],
-          "circle-stroke-color": "#ffffff",
-          "circle-stroke-opacity": disableLod
-            ? 1
-            : [
-                "step",
-                ["zoom"],
-                ["case", ["==", ["get", "gridRank"], 1], 1, 0],
-                13,
-                1,
-              ],
-          "circle-stroke-width": [
-            "interpolate",
-            ["linear"],
-            ["zoom"],
-            6,
             1,
-            11,
-            2,
           ],
-        }}
-        type={"circle"}
-      />
-
-      {/* Symbol layer for stop name labels — native collision detection and
-          importance ranking via symbol-sort-key */}
-      <Layer
-        {...(!disableLod && {
-          filter: ["step", ["zoom"], ["==", ["get", "gridRank"], 1], 13, true],
-        })}
-        id={STOP_LABELS_LAYER_ID}
-        layout={{
-          "symbol-sort-key": ["get", "priority"],
-          "text-allow-overlap": false,
-          "text-anchor": "right",
-          // Only show labels at zoom 14+; collision detection hides overlaps
-          "text-field": ["step", ["zoom"], "", 10, ["get", "stopName"]],
-          "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
-          "text-offset": [-1, 0],
-          // Show the circle pin even when the label text collides
-          "text-optional": true,
-          "text-size": 12,
-        }}
-        paint={{
           "text-color": textColor,
           "text-halo-color": textHaloColor,
           "text-halo-width": 1,

--- a/client/src/features/map/components/Vehicle/VehicleLayer.tsx
+++ b/client/src/features/map/components/Vehicle/VehicleLayer.tsx
@@ -8,11 +8,12 @@ import {
   useLayerEvents,
   useMapClick,
 } from "features/map/hooks/useLayerEvents";
+import { GeneratedImage, useMapImage } from "features/map/hooks/useMapImage";
 import { toPointFeatureCollection } from "features/map/utils/geojson";
 import { useAtom, useSetAtom } from "jotai";
 import * as React from "react";
-import { FC, useCallback, useEffect, useMemo, useRef } from "react";
-import { Layer, MapRef, Source, useMap } from "react-map-gl/mapbox";
+import { FC, useCallback, useMemo, useRef } from "react";
+import { Layer, Source } from "react-map-gl/mapbox";
 import { useNavigate } from "react-router-dom";
 import { useViewStatePathname } from "shared/hooks/UseViewStatePathname";
 import {
@@ -32,14 +33,13 @@ const VEHICLE_ARROW_IMAGE_ID = "vehicle-arrow";
 const VEHICLE_LAYER_IDS = [VEHICLE_CIRCLES_LAYER_ID];
 const VEHICLES_SOURCE_ID = "vehicles-source";
 
-function addVehicleArrowImage(map: MapRef) {
-  if (map.hasImage(VEHICLE_ARROW_IMAGE_ID)) return;
+function createVehicleArrowImage(): GeneratedImage | null {
   const size = 32;
   const canvas = document.createElement("canvas");
   canvas.width = size;
   canvas.height = size;
   const ctx = canvas.getContext("2d");
-  if (!ctx) return;
+  if (!ctx) return null;
 
   const cx = size / 2;
   // Navigation chevron: the same pattern used by Google Maps / Apple Maps / Waze
@@ -67,11 +67,7 @@ function addVehicleArrowImage(map: MapRef) {
   ctx.stroke();
 
   const imageData = ctx.getImageData(0, 0, size, size);
-  map.addImage(VEHICLE_ARROW_IMAGE_ID, {
-    width: size,
-    height: size,
-    data: imageData.data as unknown as Uint8Array,
-  });
+  return { width: size, height: size, data: imageData.data };
 }
 
 interface VehicleLayerProps {
@@ -79,7 +75,6 @@ interface VehicleLayerProps {
 }
 
 export const VehicleLayer: FC<VehicleLayerProps> = ({ vehiclePositions }) => {
-  const { mapId: map } = useMap();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const navigate = useNavigate();
@@ -99,15 +94,7 @@ export const VehicleLayer: FC<VehicleLayerProps> = ({ vehiclePositions }) => {
   );
   const { scheduleClose, cancelClose } = useHoverClose(closeHoverPopup);
 
-  // Add custom arrow image to map on load
-  useEffect(() => {
-    if (!map) return;
-    if (map.isStyleLoaded()) {
-      addVehicleArrowImage(map);
-    } else {
-      map.once("load", () => addVehicleArrowImage(map));
-    }
-  }, [map]);
+  useMapImage(VEHICLE_ARROW_IMAGE_ID, createVehicleArrowImage);
 
   // Lookup map for click/hover resolution
   const vehiclesById = useMemo(() => {

--- a/client/src/features/map/hooks/useMapImage.test.tsx
+++ b/client/src/features/map/hooks/useMapImage.test.tsx
@@ -1,0 +1,90 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { GeneratedImage, useMapImage } from "./useMapImage";
+
+const mocks = vi.hoisted(() => {
+  const map = {
+    hasImage: vi.fn(() => false),
+    addImage: vi.fn(),
+    isStyleLoaded: vi.fn(() => true),
+    once: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+  return { map, useMap: vi.fn(() => ({ mapId: map })) };
+});
+
+vi.mock("react-map-gl/mapbox", () => ({
+  useMap: mocks.useMap,
+}));
+
+const image: GeneratedImage = {
+  width: 2,
+  height: 2,
+  data: new Uint8ClampedArray(16),
+};
+const createImage = vi.fn(() => image);
+
+describe("useMapImage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.map.hasImage.mockReturnValue(false);
+    mocks.map.isStyleLoaded.mockReturnValue(true);
+    mocks.useMap.mockReturnValue({ mapId: mocks.map });
+    createImage.mockReturnValue(image);
+  });
+
+  test("adds the image when the style is loaded", () => {
+    renderHook(() => useMapImage("img", createImage, true));
+
+    expect(mocks.map.addImage).toHaveBeenCalledWith(
+      "img",
+      expect.objectContaining({ width: 2, height: 2 }),
+      { sdf: true }
+    );
+  });
+
+  test("defers to the load event when the style is not ready", () => {
+    mocks.map.isStyleLoaded.mockReturnValue(false);
+
+    renderHook(() => useMapImage("img", createImage));
+
+    expect(mocks.map.addImage).not.toHaveBeenCalled();
+    expect(mocks.map.once).toHaveBeenCalledWith("load", expect.any(Function));
+
+    mocks.map.once.mock.calls[0][1]();
+    expect(mocks.map.addImage).toHaveBeenCalled();
+  });
+
+  test("does not re-add an existing image", () => {
+    mocks.map.hasImage.mockReturnValue(true);
+
+    renderHook(() => useMapImage("img", createImage));
+
+    expect(mocks.map.addImage).not.toHaveBeenCalled();
+    expect(createImage).not.toHaveBeenCalled();
+  });
+
+  test("re-adds the image when the style reports it missing", () => {
+    mocks.map.hasImage.mockReturnValue(true);
+    renderHook(() => useMapImage("img", createImage));
+    expect(mocks.map.addImage).not.toHaveBeenCalled();
+
+    const onImageMissing = mocks.map.on.mock.calls.find(
+      (c) => c[0] === "styleimagemissing"
+    )?.[1];
+    mocks.map.hasImage.mockReturnValue(false);
+    onImageMissing({ id: "img" });
+
+    expect(mocks.map.addImage).toHaveBeenCalled();
+  });
+
+  test("skips when the factory returns null (e.g. no canvas context)", () => {
+    createImage.mockReturnValue(null as unknown as GeneratedImage);
+
+    renderHook(() => useMapImage("img", createImage));
+
+    expect(mocks.map.addImage).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/features/map/hooks/useMapImage.tsx
+++ b/client/src/features/map/hooks/useMapImage.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from "react";
+import { useMap } from "react-map-gl/mapbox";
+
+export interface GeneratedImage {
+  width: number;
+  height: number;
+  data: Uint8ClampedArray;
+}
+
+/**
+ * Adds a programmatically generated image to the map style once it has
+ * loaded, so symbol layers can reference it via icon-image. The factory
+ * must be a stable (module-level) function.
+ */
+export const useMapImage = (
+  imageId: string,
+  createImage: () => GeneratedImage | null,
+  sdf = false
+) => {
+  const { mapId: map } = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+    const addImage = () => {
+      if (map.hasImage(imageId)) return;
+      const image = createImage();
+      if (!image) return;
+      map.addImage(
+        imageId,
+        {
+          width: image.width,
+          height: image.height,
+          data: image.data as unknown as Uint8Array,
+        },
+        { sdf }
+      );
+    };
+    // A layer can request the image before the style has loaded it;
+    // styleimagemissing closes that race
+    const onImageMissing = (e: { id: string }) => {
+      if (e.id === imageId) addImage();
+    };
+    map.on("styleimagemissing", onImageMissing);
+    if (map.isStyleLoaded()) {
+      addImage();
+    } else {
+      map.once("load", addImage);
+    }
+    return () => {
+      map.off("styleimagemissing", onImageMissing);
+    };
+  }, [map, imageId, createImage, sdf]);
+};


### PR DESCRIPTION
## Summary
Replaces the hand-rolled label-grid decluttering (`buildLabelGridWinners`/`gridRank`) with Mapbox's native collision engine. Circle layers can't collide, so the stop dot becomes an SDF icon on a single merged symbol layer:

- **Dots declutter natively**: the placement engine shows as many dots as fit at every zoom, screen-space-adaptive and continuous instead of the fixed geographic grid stepping at zoom 13; zoom-interpolated `icon-padding` spaces them out at city zoom
- **Priority preserved**: `symbol-sort-key` still favors stops serving more routes
- **Labels improve**: `text-variable-anchor` lets labels slide to whichever side fits (more labels placed downtown); `text-optional` drops the label before the dot under pressure
- **SDF sprite keeps all styling**: per-feature `icon-color` (selected red + hover feature-state red, like before), white ring via `icon-halo-*`
- **Route pages unchanged**: `disableLod` maps to `icon-allow-overlap: true` so every route stop stays visible
- Image loading extracted to a shared `useMapImage` hook (with a `styleimagemissing` listener closing the startup race that briefly logged a missing-image warning); VehicleLayer's arrow migrated to it
- Net deletion: the grid computation, integer-zoom tracking state, and `gridRank` plumbing are gone

## Test plan
- [x] 184/184 tests pass (useMapImage tests added; StopLayer/Map tests updated for the merged layer), lint + format clean, build succeeds, no new type errors
- [x] Chrome at city zoom: dots evenly spaced with white halos, no console warnings/expression errors
- [x] Chrome at z15.5 downtown: larger dots, labels anchored to whichever side fits
- [x] Hover: dot turns red via feature-state, popup appears and survives mouse-over
- [x] Click: stop selected and navigated, selected dot stays red

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2