### PR TITLE
Redesign map icons: bus stop flags and vehicle teardrop pointers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
 terraform/terraform.tfvars
 terraform/*.tfvars
+.superpowers/

--- a/client/src/features/map/components/Map.test.tsx
+++ b/client/src/features/map/components/Map.test.tsx
@@ -47,7 +47,7 @@ vi.mock("./Stop/StopLayer", () => ({
 }));
 
 vi.mock("./Vehicle/VehicleLayer", () => ({
-  VEHICLE_CIRCLES_LAYER_ID: "vehicle-circles",
+  VEHICLES_LAYER_ID: "vehicle-markers",
   VehicleLayer: (props: Record<string, unknown>) => {
     mocks.vehicleLayerProps(props);
     return <div data-testid={"vehicle-layer"} />;
@@ -126,7 +126,7 @@ describe("Map", () => {
 
     expect(mocks.mapProps).toHaveBeenCalledWith(
       expect.objectContaining({
-        interactiveLayerIds: ["stops", "vehicle-circles"],
+        interactiveLayerIds: ["stops", "vehicle-markers"],
       })
     );
   });

--- a/client/src/features/map/components/Map.tsx
+++ b/client/src/features/map/components/Map.tsx
@@ -18,7 +18,7 @@ import { useCurrentStop } from "shared/hooks/UseCurrentStop";
 import { useViewStatePathname } from "shared/hooks/UseViewStatePathname";
 
 import { STOPS_LAYER_ID, StopLayer } from "./Stop/StopLayer";
-import { VEHICLE_CIRCLES_LAYER_ID, VehicleLayer } from "./Vehicle/VehicleLayer";
+import { VEHICLES_LAYER_ID, VehicleLayer } from "./Vehicle/VehicleLayer";
 
 export type ViewState = {
   /** Longitude at map center */
@@ -76,7 +76,7 @@ export const Map: React.FunctionComponent = () => {
       id={"mapId"}
       {...viewState}
       cursor={cursor}
-      interactiveLayerIds={[STOPS_LAYER_ID, VEHICLE_CIRCLES_LAYER_ID]}
+      interactiveLayerIds={[STOPS_LAYER_ID, VEHICLES_LAYER_ID]}
       mapStyle={
         darkMode
           ? "mapbox://styles/mapbox/dark-v11"

--- a/client/src/features/map/components/Stop/StopLayer.tsx
+++ b/client/src/features/map/components/Stop/StopLayer.tsx
@@ -7,8 +7,15 @@ import {
   LayerMouseEvent,
   useLayerEvents,
 } from "features/map/hooks/useLayerEvents";
-import { GeneratedImage, useMapImage } from "features/map/hooks/useMapImage";
+import { useMapImage } from "features/map/hooks/useMapImage";
 import { toPointFeatureCollection } from "features/map/utils/geojson";
+import {
+  createStopFlagFar,
+  createStopFlagFarSelected,
+  createStopFlagNear,
+  createStopFlagNearSelected,
+  SELECTED_RED,
+} from "features/map/utils/mapSprites";
 import { useAtom, useSetAtom } from "jotai";
 import * as React from "react";
 import { FC, useCallback, useMemo } from "react";
@@ -25,38 +32,19 @@ import { StopPeekSheet } from "./StopPeekSheet";
 import { StopPopupContent } from "./StopPopupContent";
 
 export const STOPS_LAYER_ID = "stops";
+const STOPS_HOVER_LAYER_ID = "stops-hover";
 const STOP_LAYER_IDS = [STOPS_LAYER_ID];
 const STOPS_SOURCE_ID = "stops-source";
-const STOP_DOT_IMAGE_ID = "stop-dot";
 
-/**
- * SDF sprite for the stop dot. Icons (unlike circle layers) participate in
- * Mapbox's native collision engine, which is what declutters the ~2,300
- * stops at low zoom. Encoding the circle as a signed distance field lets
- * the style recolor it per-feature (icon-color supports feature-state,
- * which layout-time icon switching does not) and draw the white ring via
- * icon-halo-*.
- */
-const DOT_SPRITE_SIZE = 64;
-const DOT_SPRITE_RADIUS = 20;
-const DOT_SDF_SPREAD = 8;
+// Baked two-color "bus stop flag" sprites (see mapSprites.ts). The far
+// variant is a plain rounded square — the glyph is unreadable below ~14px.
+const FLAG_FAR_IMAGE_ID = "stop-flag-far";
+const FLAG_FAR_SELECTED_IMAGE_ID = "stop-flag-far-selected";
+const FLAG_NEAR_IMAGE_ID = "stop-flag";
+const FLAG_NEAR_SELECTED_IMAGE_ID = "stop-flag-selected";
 
-function createStopDotImage(): GeneratedImage {
-  const size = DOT_SPRITE_SIZE;
-  const data = new Uint8ClampedArray(size * size * 4);
-  const center = size / 2;
-  for (let y = 0; y < size; y++) {
-    for (let x = 0; x < size; x++) {
-      const distance =
-        Math.hypot(x - center + 0.5, y - center + 0.5) - DOT_SPRITE_RADIUS;
-      // Mapbox's SDF shader draws the shape where alpha ≈ 0.75+; the
-      // falloff below that leaves room for the halo ring
-      const alpha = Math.max(0, Math.min(1, 0.75 - distance / DOT_SDF_SPREAD));
-      data[(y * size + x) * 4 + 3] = Math.round(alpha * 255);
-    }
-  }
-  return { width: size, height: size, data };
-}
+/** Zoom at which the flag gains its bus glyph. */
+const GLYPH_ZOOM = 13;
 
 interface StopLayerProps {
   readonly darkMode?: boolean;
@@ -85,7 +73,10 @@ export const StopLayer: FC<StopLayerProps> = ({
   );
   const { scheduleClose, cancelClose } = useHoverClose(closeHoverPopup);
 
-  useMapImage(STOP_DOT_IMAGE_ID, createStopDotImage, true);
+  useMapImage(FLAG_FAR_IMAGE_ID, createStopFlagFar);
+  useMapImage(FLAG_FAR_SELECTED_IMAGE_ID, createStopFlagFarSelected);
+  useMapImage(FLAG_NEAR_IMAGE_ID, createStopFlagNear);
+  useMapImage(FLAG_NEAR_SELECTED_IMAGE_ID, createStopFlagNearSelected);
 
   const stopsById = useMemo(() => {
     const m = new Map<string, Stop>();
@@ -168,28 +159,84 @@ export const StopLayer: FC<StopLayerProps> = ({
       promoteId={"stopId"}
       type={"geojson"}
     >
-      {/* Single symbol layer for dots + labels. The native collision engine
-          declutters both: dots thin out at low zoom (icon-padding widens the
-          collision box), and labels drop before dots do (text-optional).
+      {/* Hover ring under the flag. Flag sprites are baked (two-color, so
+          not SDF-recolorable) and layout properties can't read
+          feature-state, so hover feedback lives in this underlay. */}
+      <Layer
+        id={STOPS_HOVER_LAYER_ID}
+        paint={{
+          "circle-color": SELECTED_RED,
+          "circle-opacity": [
+            "case",
+            ["boolean", ["feature-state", "hovered"], false],
+            0.25,
+            0,
+          ],
+          "circle-radius": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            6,
+            7,
+            11,
+            9,
+            14,
+            15,
+            18,
+            21,
+          ],
+          "circle-stroke-color": SELECTED_RED,
+          "circle-stroke-opacity": [
+            "case",
+            ["boolean", ["feature-state", "hovered"], false],
+            0.9,
+            0,
+          ],
+          "circle-stroke-width": 2,
+        }}
+        type={"circle"}
+      />
+      {/* Single symbol layer for flags + labels. The native collision engine
+          declutters both: flags thin out at low zoom (icon-padding widens the
+          collision box), and labels drop before flags do (text-optional).
           On route pages (disableLod) every stop must stay visible, so icons
           are allowed to overlap. */}
       <Layer
         id={STOPS_LAYER_ID}
         layout={{
           "icon-allow-overlap": disableLod,
-          "icon-image": STOP_DOT_IMAGE_ID,
-          // Wider collision box at low zoom = fewer, better-spaced dots
+          // Plain square when far; bus-glyph flag when near. Selected stop
+          // gets the red variant (data expressions work in layout,
+          // feature-state does not).
+          "icon-image": [
+            "step",
+            ["zoom"],
+            [
+              "case",
+              ["==", ["get", "stopId"], selectedStopId],
+              FLAG_FAR_SELECTED_IMAGE_ID,
+              FLAG_FAR_IMAGE_ID,
+            ],
+            GLYPH_ZOOM,
+            [
+              "case",
+              ["==", ["get", "stopId"], selectedStopId],
+              FLAG_NEAR_SELECTED_IMAGE_ID,
+              FLAG_NEAR_IMAGE_ID,
+            ],
+          ],
+          // Wider collision box at low zoom = fewer, better-spaced flags
           "icon-padding": ["interpolate", ["linear"], ["zoom"], 8, 10, 13, 2],
           "icon-size": [
             "interpolate",
             ["linear"],
             ["zoom"],
             6,
-            0.15,
+            0.125,
             11,
-            0.2,
+            0.19,
             14,
-            0.35,
+            0.33,
             18,
             0.5,
           ],
@@ -197,7 +244,7 @@ export const StopLayer: FC<StopLayerProps> = ({
           // Labels only at zoom 10+; collision then hides overlaps
           "text-field": ["step", ["zoom"], "", 10, ["get", "stopName"]],
           "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
-          // Drop the label under collision pressure but keep the dot
+          // Drop the label under collision pressure but keep the flag
           "text-optional": true,
           "text-radial-offset": 0.8,
           "text-size": 12,
@@ -206,24 +253,6 @@ export const StopLayer: FC<StopLayerProps> = ({
           "text-variable-anchor": ["right", "left", "top", "bottom"],
         }}
         paint={{
-          "icon-color": [
-            "case",
-            ["==", ["get", "stopId"], selectedStopId],
-            "#EA4335",
-            ["boolean", ["feature-state", "hovered"], false],
-            "#EA4335",
-            "#1A73E8",
-          ],
-          "icon-halo-color": "#ffffff",
-          "icon-halo-width": [
-            "interpolate",
-            ["linear"],
-            ["zoom"],
-            6,
-            0.5,
-            11,
-            1,
-          ],
           "text-color": textColor,
           "text-halo-color": textHaloColor,
           "text-halo-width": 1,

--- a/client/src/features/map/components/Vehicle/VehicleLayer.test.tsx
+++ b/client/src/features/map/components/Vehicle/VehicleLayer.test.tsx
@@ -106,7 +106,7 @@ describe("VehicleLayer", () => {
     renderVehicleLayer();
 
     act(() => {
-      getLayerHandler("click", "vehicle-circles")(featureEvent("v1"));
+      getLayerHandler("click", "vehicle-markers")(featureEvent("v1"));
     });
 
     expect(mocks.navigate).toHaveBeenCalledWith(
@@ -119,7 +119,7 @@ describe("VehicleLayer", () => {
     renderVehicleLayer();
 
     act(() => {
-      getLayerHandler("mouseenter", "vehicle-circles")(featureEvent("v1"));
+      getLayerHandler("mouseenter", "vehicle-markers")(featureEvent("v1"));
     });
 
     expect(screen.getByTestId("vehicle-popup-content")).toHaveTextContent("v1");
@@ -132,7 +132,7 @@ describe("VehicleLayer", () => {
     // Vehicle click and background click fire on the same click; the ref
     // guard keeps the popup open the first time.
     act(() => {
-      getLayerHandler("click", "vehicle-circles")(featureEvent("v1"));
+      getLayerHandler("click", "vehicle-markers")(featureEvent("v1"));
       getMapClickHandler()();
     });
     expect(screen.getByTestId("vehicle-popup-content")).toBeInTheDocument();
@@ -151,7 +151,7 @@ describe("VehicleLayer", () => {
     renderVehicleLayer();
 
     act(() => {
-      getLayerHandler("click", "vehicle-circles")(featureEvent("v1"));
+      getLayerHandler("click", "vehicle-markers")(featureEvent("v1"));
     });
 
     expect(mocks.navigate).not.toHaveBeenCalled();
@@ -162,15 +162,15 @@ describe("VehicleLayer", () => {
     mocks.isMobile.mockReturnValue(true);
     renderVehicleLayer();
 
-    expect(getLayerHandler("mouseenter", "vehicle-circles")).toBeUndefined();
-    expect(getLayerHandler("click", "vehicle-circles")).toBeDefined();
+    expect(getLayerHandler("mouseenter", "vehicle-markers")).toBeUndefined();
+    expect(getLayerHandler("click", "vehicle-markers")).toBeDefined();
   });
 
   test("ignores clicks on unknown vehicles", () => {
     renderVehicleLayer();
 
     act(() => {
-      getLayerHandler("click", "vehicle-circles")(featureEvent("unknown"));
+      getLayerHandler("click", "vehicle-markers")(featureEvent("unknown"));
     });
 
     expect(mocks.navigate).not.toHaveBeenCalled();

--- a/client/src/features/map/components/Vehicle/VehicleLayer.tsx
+++ b/client/src/features/map/components/Vehicle/VehicleLayer.tsx
@@ -8,8 +8,18 @@ import {
   useLayerEvents,
   useMapClick,
 } from "features/map/hooks/useLayerEvents";
-import { GeneratedImage, useMapImage } from "features/map/hooks/useMapImage";
+import { useMapImage } from "features/map/hooks/useMapImage";
 import { toPointFeatureCollection } from "features/map/utils/geojson";
+import {
+  createBusGlyph,
+  createTeardropIncoming,
+  createTeardropStopped,
+  createTeardropTransit,
+  SELECTED_RED,
+  VEHICLE_INCOMING_ORANGE,
+  VEHICLE_STOPPED_RED,
+  VEHICLE_TRANSIT_BLUE,
+} from "features/map/utils/mapSprites";
 import { useAtom, useSetAtom } from "jotai";
 import * as React from "react";
 import { FC, useCallback, useMemo, useRef } from "react";
@@ -26,49 +36,17 @@ import { VehiclePosition } from "shared/types/interface.d";
 import { VehiclePeekSheet } from "./VehiclePeekSheet";
 import { VehiclePopupContainer } from "./VehiclePopupContainer";
 
-export const VEHICLE_CIRCLES_LAYER_ID = "vehicle-circles";
-const VEHICLE_ARROWS_LAYER_ID = "vehicle-arrows";
+export const VEHICLES_LAYER_ID = "vehicle-markers";
+const VEHICLES_HOVER_LAYER_ID = "vehicle-markers-hover";
+const VEHICLE_GLYPHS_LAYER_ID = "vehicle-glyphs";
 const VEHICLE_LABELS_LAYER_ID = "vehicle-labels";
-const VEHICLE_ARROW_IMAGE_ID = "vehicle-arrow";
-const VEHICLE_LAYER_IDS = [VEHICLE_CIRCLES_LAYER_ID];
+const VEHICLE_LAYER_IDS = [VEHICLES_LAYER_ID];
 const VEHICLES_SOURCE_ID = "vehicles-source";
 
-function createVehicleArrowImage(): GeneratedImage | null {
-  const size = 32;
-  const canvas = document.createElement("canvas");
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext("2d");
-  if (!ctx) return null;
-
-  const cx = size / 2;
-  // Navigation chevron: the same pattern used by Google Maps / Apple Maps / Waze
-  // for live vehicle direction — a solid arrowhead with a notched tail so it
-  // reads as motion rather than a static triangle.
-  //
-  //       ^   ← tip (north / direction of travel)
-  //      / \
-  //     /   \
-  //    / · · \
-  //   /___^___\  ← notched rear
-  //
-  ctx.fillStyle = "rgba(255, 255, 255, 0.95)";
-  ctx.beginPath();
-  ctx.moveTo(cx, 2); // tip
-  ctx.lineTo(cx + 11, size - 4); // bottom-right
-  ctx.lineTo(cx, size - 10); // rear notch (inner)
-  ctx.lineTo(cx - 11, size - 4); // bottom-left
-  ctx.closePath();
-  ctx.fill();
-
-  // Thin dark stroke so the white arrow is visible on light-coloured circles
-  ctx.strokeStyle = "rgba(0, 0, 0, 0.15)";
-  ctx.lineWidth = 0.75;
-  ctx.stroke();
-
-  const imageData = ctx.getImageData(0, 0, size, size);
-  return { width: size, height: size, data: imageData.data };
-}
+const TEARDROP_TRANSIT_IMAGE_ID = "vehicle-teardrop-transit";
+const TEARDROP_INCOMING_IMAGE_ID = "vehicle-teardrop-incoming";
+const TEARDROP_STOPPED_IMAGE_ID = "vehicle-teardrop-stopped";
+const BUS_GLYPH_IMAGE_ID = "vehicle-bus-glyph";
 
 interface VehicleLayerProps {
   readonly vehiclePositions: VehiclePosition[];
@@ -94,7 +72,10 @@ export const VehicleLayer: FC<VehicleLayerProps> = ({ vehiclePositions }) => {
   );
   const { scheduleClose, cancelClose } = useHoverClose(closeHoverPopup);
 
-  useMapImage(VEHICLE_ARROW_IMAGE_ID, createVehicleArrowImage);
+  useMapImage(TEARDROP_TRANSIT_IMAGE_ID, createTeardropTransit);
+  useMapImage(TEARDROP_INCOMING_IMAGE_ID, createTeardropIncoming);
+  useMapImage(TEARDROP_STOPPED_IMAGE_ID, createTeardropStopped);
+  useMapImage(BUS_GLYPH_IMAGE_ID, createBusGlyph);
 
   // Lookup map for click/hover resolution
   const vehiclesById = useMemo(() => {
@@ -203,67 +184,91 @@ export const VehicleLayer: FC<VehicleLayerProps> = ({ vehiclePositions }) => {
       promoteId={"vehicleId"}
       type={"geojson"}
     >
-      {/* Circle layer: orange dot at each vehicle position */}
+      {/* Hover ring under the teardrop (baked sprites can't recolor on
+          feature-state, so hover feedback lives in this underlay) */}
       <Layer
-        id={VEHICLE_CIRCLES_LAYER_ID}
+        id={VEHICLES_HOVER_LAYER_ID}
         paint={{
-          "circle-color": [
+          "circle-color": SELECTED_RED,
+          "circle-opacity": [
             "case",
             ["boolean", ["feature-state", "hovered"], false],
-            // Hovered: darken each state color
-            [
-              "match",
-              ["get", "currentStatus"],
-              "STOPPED_AT",
-              "#B71C1C",
-              "INCOMING_AT",
-              "#E65100",
-              /* IN_TRANSIT_TO + default */ "#1565C0",
-            ],
-            // Normal
-            [
-              "match",
-              ["get", "currentStatus"],
-              "STOPPED_AT",
-              "#F44336",
-              "INCOMING_AT",
-              "#FF9800",
-              /* IN_TRANSIT_TO + default */ "#1E88E5",
-            ],
+            0.25,
+            0,
           ],
           "circle-radius": [
             "interpolate",
             ["linear"],
             ["zoom"],
             10,
-            6,
+            11,
             14,
-            9,
+            15,
             18,
-            13,
+            20,
           ],
-          "circle-stroke-color": "#ffffff",
+          "circle-stroke-color": SELECTED_RED,
+          "circle-stroke-opacity": [
+            "case",
+            ["boolean", ["feature-state", "hovered"], false],
+            0.9,
+            0,
+          ],
           "circle-stroke-width": 2,
         }}
         type={"circle"}
       />
 
-      {/* Arrow layer: directional indicator rotated by bearing */}
+      {/* Teardrop marker: bulb centered on the vehicle position, tip
+          rotated to the heading — replaces the old circle + chevron */}
       <Layer
-        id={VEHICLE_ARROWS_LAYER_ID}
+        id={VEHICLES_LAYER_ID}
         layout={{
           "icon-allow-overlap": true,
-          "icon-image": VEHICLE_ARROW_IMAGE_ID,
+          "icon-image": [
+            "match",
+            ["get", "currentStatus"],
+            "STOPPED_AT",
+            TEARDROP_STOPPED_IMAGE_ID,
+            "INCOMING_AT",
+            TEARDROP_INCOMING_IMAGE_ID,
+            /* IN_TRANSIT_TO + default */ TEARDROP_TRANSIT_IMAGE_ID,
+          ],
           "icon-rotate": ["get", "bearing"],
           "icon-rotation-alignment": "map",
-          "icon-size": 0.85,
+          "icon-size": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            10,
+            0.35,
+            14,
+            0.5,
+            18,
+            0.68,
+          ],
         }}
-        paint={{
-          "icon-opacity": [
-            "case",
-            ["boolean", ["feature-state", "hovered"], false],
-            1,
-            0.8,
+        type={"symbol"}
+      />
+
+      {/* Bus glyph: separate viewport-aligned layer so the bus stays
+          upright while the teardrop under it rotates with the bearing */}
+      <Layer
+        id={VEHICLE_GLYPHS_LAYER_ID}
+        layout={{
+          "icon-allow-overlap": true,
+          "icon-ignore-placement": true,
+          "icon-image": BUS_GLYPH_IMAGE_ID,
+          "icon-size": [
+            "interpolate",
+            ["linear"],
+            ["zoom"],
+            10,
+            0.26,
+            14,
+            0.36,
+            18,
+            0.5,
           ],
         }}
         type={"symbol"}
@@ -285,10 +290,10 @@ export const VehicleLayer: FC<VehicleLayerProps> = ({ vehiclePositions }) => {
             "match",
             ["get", "currentStatus"],
             "STOPPED_AT",
-            "#F44336",
+            VEHICLE_STOPPED_RED,
             "INCOMING_AT",
-            "#FF9800",
-            "#1E88E5",
+            VEHICLE_INCOMING_ORANGE,
+            VEHICLE_TRANSIT_BLUE,
           ],
           "text-halo-width": 1.5,
         }}

--- a/client/src/features/map/utils/mapSprites.ts
+++ b/client/src/features/map/utils/mapSprites.ts
@@ -1,0 +1,187 @@
+/**
+ * Canvas-generated map sprites for the stop flag and vehicle teardrop
+ * markers. All sprites are baked (non-SDF) because they are two-color;
+ * hover feedback therefore comes from feature-state-driven underlay circle
+ * layers rather than icon recoloring (layout properties like icon-image
+ * cannot read feature-state).
+ */
+
+import { GeneratedImage } from "features/map/hooks/useMapImage";
+
+export const STOP_BLUE = "#1A73E8";
+export const SELECTED_RED = "#EA4335";
+export const VEHICLE_TRANSIT_BLUE = "#1E88E5";
+export const VEHICLE_INCOMING_ORANGE = "#FF9800";
+export const VEHICLE_STOPPED_RED = "#F44336";
+
+/** Flag sprite canvas is 64px with a 48px rounded square centered in it. */
+export const FLAG_SPRITE_SIZE = 64;
+/** Teardrop sprite canvas is 80px; the 44px bulb is centered so rotation
+ * pivots around the vehicle position. */
+export const TEARDROP_SPRITE_SIZE = 80;
+export const TEARDROP_BULB_RADIUS = 22;
+/** Standalone glyph canvas is 64px with a 34px-tall bus centered in it. */
+export const GLYPH_SPRITE_SIZE = 64;
+export const GLYPH_BUS_HEIGHT = 34;
+
+function withCanvas(
+  size: number,
+  draw: (ctx: CanvasRenderingContext2D) => void
+): GeneratedImage | null {
+  const canvas = document.createElement("canvas");
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  draw(ctx);
+  const imageData = ctx.getImageData(0, 0, size, size);
+  return { width: size, height: size, data: imageData.data };
+}
+
+function roundRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  r: number
+) {
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.arcTo(x + w, y, x + w, y + h, r);
+  ctx.arcTo(x + w, y + h, x, y + h, r);
+  ctx.arcTo(x, y + h, x, y, r);
+  ctx.arcTo(x, y, x + w, y, r);
+  ctx.closePath();
+}
+
+/**
+ * Front-view bus centered at (cx, cy) with the given overall height.
+ * If windshieldColor is omitted the windshield is knocked out to
+ * transparent (for the standalone glyph that floats over the teardrop).
+ */
+function drawBusGlyph(
+  ctx: CanvasRenderingContext2D,
+  cx: number,
+  cy: number,
+  height: number,
+  color: string,
+  windshieldColor?: string
+) {
+  const h = height;
+  const w = h * 0.92;
+  const x = cx - w / 2;
+  const y = cy - h / 2;
+
+  // Body
+  ctx.fillStyle = color;
+  roundRectPath(ctx, x, y, w, h * 0.84, h * 0.14);
+  ctx.fill();
+
+  // Windshield
+  const wsX = x + w * 0.16;
+  const wsY = y + h * 0.15;
+  const wsW = w * 0.68;
+  const wsH = h * 0.27;
+  if (windshieldColor === undefined) {
+    ctx.globalCompositeOperation = "destination-out";
+    roundRectPath(ctx, wsX, wsY, wsW, wsH, h * 0.06);
+    ctx.fill();
+    ctx.globalCompositeOperation = "source-over";
+  } else {
+    ctx.fillStyle = windshieldColor;
+    roundRectPath(ctx, wsX, wsY, wsW, wsH, h * 0.06);
+    ctx.fill();
+    ctx.fillStyle = color;
+  }
+
+  // Wheels
+  ctx.beginPath();
+  ctx.arc(x + w * 0.28, y + h * 0.94, h * 0.1, 0, 2 * Math.PI);
+  ctx.arc(x + w * 0.72, y + h * 0.94, h * 0.1, 0, 2 * Math.PI);
+  ctx.fill();
+}
+
+function drawStopFlag(
+  ctx: CanvasRenderingContext2D,
+  color: string,
+  withGlyph: boolean
+) {
+  const inset = 8;
+  const square = FLAG_SPRITE_SIZE - inset * 2;
+
+  ctx.fillStyle = color;
+  roundRectPath(ctx, inset, inset, square, square, 13);
+  ctx.fill();
+  ctx.strokeStyle = "#ffffff";
+  ctx.lineWidth = 4.5;
+  ctx.stroke();
+
+  if (withGlyph) {
+    drawBusGlyph(
+      ctx,
+      FLAG_SPRITE_SIZE / 2,
+      FLAG_SPRITE_SIZE / 2,
+      square * 0.62,
+      "#ffffff",
+      color
+    );
+  }
+}
+
+function drawTeardrop(ctx: CanvasRenderingContext2D, color: string) {
+  const c = TEARDROP_SPRITE_SIZE / 2;
+  const r = TEARDROP_BULB_RADIUS;
+  // Tangent points where the tip's straight edges meet the bulb
+  const tangentX = 15;
+  const tangentY = 16;
+  const startAngle = Math.atan2(-tangentY, -tangentX);
+  const endAngle = Math.atan2(-tangentY, tangentX);
+
+  ctx.beginPath();
+  ctx.moveTo(c, 5); // tip (north; icon-rotate points it along the bearing)
+  ctx.lineTo(c - tangentX, c - tangentY);
+  // Long way around the bottom of the bulb
+  ctx.arc(c, c, r, startAngle, endAngle, true);
+  ctx.closePath();
+  ctx.fillStyle = color;
+  ctx.fill();
+  ctx.strokeStyle = "#ffffff";
+  ctx.lineWidth = 4;
+  ctx.stroke();
+}
+
+// Module-level factory instances so useMapImage effect deps stay stable
+
+export const createStopFlagFar = () =>
+  withCanvas(FLAG_SPRITE_SIZE, (ctx) => drawStopFlag(ctx, STOP_BLUE, false));
+export const createStopFlagFarSelected = () =>
+  withCanvas(FLAG_SPRITE_SIZE, (ctx) => drawStopFlag(ctx, SELECTED_RED, false));
+export const createStopFlagNear = () =>
+  withCanvas(FLAG_SPRITE_SIZE, (ctx) => drawStopFlag(ctx, STOP_BLUE, true));
+export const createStopFlagNearSelected = () =>
+  withCanvas(FLAG_SPRITE_SIZE, (ctx) => drawStopFlag(ctx, SELECTED_RED, true));
+
+export const createTeardropTransit = () =>
+  withCanvas(TEARDROP_SPRITE_SIZE, (ctx) =>
+    drawTeardrop(ctx, VEHICLE_TRANSIT_BLUE)
+  );
+export const createTeardropIncoming = () =>
+  withCanvas(TEARDROP_SPRITE_SIZE, (ctx) =>
+    drawTeardrop(ctx, VEHICLE_INCOMING_ORANGE)
+  );
+export const createTeardropStopped = () =>
+  withCanvas(TEARDROP_SPRITE_SIZE, (ctx) =>
+    drawTeardrop(ctx, VEHICLE_STOPPED_RED)
+  );
+
+export const createBusGlyph = () =>
+  withCanvas(GLYPH_SPRITE_SIZE, (ctx) =>
+    drawBusGlyph(
+      ctx,
+      GLYPH_SPRITE_SIZE / 2,
+      GLYPH_SPRITE_SIZE / 2,
+      GLYPH_BUS_HEIGHT,
+      "#ffffff"
+    )
+  );

--- a/docs/superpowers/specs/2026-07-11-map-icons-design.md
+++ b/docs/superpowers/specs/2026-07-11-map-icons-design.md
@@ -1,0 +1,65 @@
+# Map Icon Redesign: Stop Flags & Vehicle Teardrops
+
+**Date:** 2026-07-11 · **Status:** Approved (option B of three directions)
+
+## Goal
+
+Make the map icons transit-recognizable: stops read as "bus stop", vehicles
+read as "bus", at a glance. Direction chosen from three visual mockups:
+rounded-square stop flags and rotating teardrop vehicle pointers, keeping the
+existing status colors (blue in transit / orange incoming / red stopped) and
+all decluttering behavior from the native-collision work (PR #165).
+
+## Constraints that shape the design
+
+- SDF sprites (today's stop dot) are single-color; the flag and teardrop are
+  two-color (colored body + white glyph), so sprites are **baked (non-SDF)
+  canvas images**.
+- `icon-image` is a layout property: it can switch on zoom and feature
+  properties, but **not** on `feature-state` — so hover cannot recolor a
+  baked sprite. Hover feedback moves to a feature-state-driven **underlay
+  circle layer** (soft red ring, invisible unless hovered).
+- A glyph baked into a rotating sprite would rotate with it (upside-down bus
+  heading south), so the vehicle glyph is a **separate viewport-aligned
+  symbol layer** that never rotates.
+
+## Stop layer
+
+- Sprites (all canvas-generated via `useMapImage`): `stop-flag-far`
+  (rounded square, no glyph) and `stop-flag` (square + white bus glyph),
+  each in blue and selected-red — 4 images.
+- `icon-image`: zoom `step` picks far/near at z13 (glyphs are unreadable
+  below ~14px), nested `case` on `selectedStopId` picks the red variant.
+- Hover: `stops-hover` circle layer under the symbol layer;
+  `circle-opacity`/`circle-stroke-opacity` are 0 unless
+  `feature-state.hovered`.
+- Unchanged from PR #165: collision decluttering, zoom-interpolated
+  `icon-padding`, `symbol-sort-key` by route count, `text-variable-anchor`
+  labels, `icon-allow-overlap` on route pages (`disableLod`).
+
+## Vehicle layer
+
+- Sprites: three teardrops (blue/orange/red, white outline), bulb centered
+  on the canvas so `icon-rotate: bearing` pivots around the bus position;
+  tip replaces the old chevron layer. Plus one white bus glyph.
+- Layers, in order: `vehicles-hover` underlay circle (feature-state ring) →
+  `vehicle-markers` teardrop symbol layer (`icon-image` matches
+  `currentStatus`, `icon-rotation-alignment: map`) → glyph layer
+  (viewport-aligned, `icon-ignore-placement`, non-interactive) → existing
+  route-number label layer.
+- The old circle layer, arrow layer, and hover-darkened color variants are
+  deleted. Interactive layer id changes ripple to Map.tsx and tests.
+
+## Testing
+
+- Unit: layer ids/registration updates in StopLayer/VehicleLayer/Map tests;
+  sprite factories return null without canvas (jsdom) — covered by the
+  existing `useMapImage` null contract.
+- Visual (Chrome): far/near zoom appearance, glyph switch at z13, hover
+  ring, selected red flag, teardrop rotation matching bearing, route pages
+  showing all stops.
+
+## Risk / fallback
+
+If rotating teardrops read badly with dense downtown traffic, keep the
+bulb-with-glyph and reinstate the rim chevron; everything else stands.


### PR DESCRIPTION
## Summary
Makes the map icons transit-recognizable (design direction chosen from three visual mockups; spec in `docs/superpowers/specs/2026-07-11-map-icons-design.md`):

- **Stops** — rounded-square "bus stop flag" sprites: plain square at city zoom, white bus glyph appears at z13 where it's legible, selected stop turns red (`icon-image` zoom-step + selected-id case)
- **Vehicles** — status-colored teardrop pointers rotated by bearing (tip replaces the old chevron layer), with a separate viewport-aligned white bus glyph above so the bus stays upright at any heading
- **Hover** — sprites are two-color and therefore baked/non-SDF, and layout properties can't read feature-state, so hover recoloring is replaced with feature-state-driven red ring underlays on both stops and vehicles
- All decluttering behavior from #165 carries over: native collision, zoom-interpolated padding, route-count sort keys, variable-anchor labels, all-stops-visible on route pages
- New `mapSprites.ts` module generates every sprite on canvas at runtime — no image assets

## Test plan
- [x] 184/184 tests pass, lint clean, production build succeeds
- [x] Visually verified on the dev server: flags at far/near zoom with glyph switch, teardrop rotation, upright glyphs, hover rings, selected red flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2