### PR TITLE
Add spatial and stop-lookup indexes, apply indexes unconditionally

### DIFF
--- a/etl/load_db.py
+++ b/etl/load_db.py
@@ -105,6 +105,11 @@ def load_database(database_url):
 
     if current_feed and current_feed == new_feed:
         print(f"Feed start date unchanged ({current_feed}), skipping database reload.")
+        # Still apply indexes (idempotent) so newly added ones reach the
+        # database without waiting for a feed change — same reasoning as
+        # extensions.sql above.
+        print("Ensuring indexes...")
+        run_sql_file(database_url, SQL_DIR / "indexes.sql")
         generate_summary(current_feed, new_feed, feed_end)
         return
 

--- a/etl/sql/indexes.sql
+++ b/etl/sql/indexes.sql
@@ -1,17 +1,27 @@
 -- Indexes are created after bulk data load for significantly faster COPY performance.
 -- PostgreSQL builds these indexes in bulk, which is much faster than maintaining
 -- them incrementally during row-by-row insertion.
+--
+-- Everything here must stay idempotent (IF NOT EXISTS): the ETL also runs
+-- this file when the feed is unchanged and the reload is skipped, so newly
+-- added indexes reach the database without waiting for a new feed.
 
-CREATE INDEX SHAPES_shape_id ON shapes(shape_id);
-CREATE INDEX TRIPS_trip_id_route_id ON trips(trip_id, route_id);
-CREATE INDEX TRIPS_trip_id_direction_id ON trips(trip_id, direction_id);
-CREATE INDEX STOP_TIMES_trip_id ON stop_times(trip_id);
-CREATE INDEX STOP_TIMES_trip_id_stop_id ON stop_times(trip_id, stop_id);
-CREATE INDEX ROUTES_AT_STOP_stop_id_route_id ON routes_at_stop(stop_id, route_id);
-CREATE INDEX TRANSFERS_from_stop_id_to_stop_id ON transfers(from_stop_id, to_stop_id);
+CREATE INDEX IF NOT EXISTS SHAPES_shape_id ON shapes(shape_id);
+CREATE INDEX IF NOT EXISTS TRIPS_trip_id_route_id ON trips(trip_id, route_id);
+CREATE INDEX IF NOT EXISTS TRIPS_trip_id_direction_id ON trips(trip_id, direction_id);
+CREATE INDEX IF NOT EXISTS STOP_TIMES_trip_id ON stop_times(trip_id);
+CREATE INDEX IF NOT EXISTS STOP_TIMES_trip_id_stop_id ON stop_times(trip_id, stop_id);
+CREATE INDEX IF NOT EXISTS ROUTES_AT_STOP_stop_id_route_id ON routes_at_stop(stop_id, route_id);
+CREATE INDEX IF NOT EXISTS TRANSFERS_from_stop_id_to_stop_id ON transfers(from_stop_id, to_stop_id);
 
 -- Trigram indexes backing the fuzzy search queries
-CREATE INDEX STOPS_stop_name_trgm ON stops USING gin (stop_name gin_trgm_ops);
-CREATE INDEX STOPS_on_street_trgm ON stops USING gin (on_street gin_trgm_ops);
-CREATE INDEX STOPS_at_street_trgm ON stops USING gin (at_street gin_trgm_ops);
-CREATE INDEX ROUTES_route_long_name_trgm ON routes USING gin (route_long_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS STOPS_stop_name_trgm ON stops USING gin (stop_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS STOPS_on_street_trgm ON stops USING gin (on_street gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS STOPS_at_street_trgm ON stops USING gin (at_street gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS ROUTES_route_long_name_trgm ON routes USING gin (route_long_name gin_trgm_ops);
+
+-- Spatial index backing nearByStops' ST_Intersects/ST_Distance
+CREATE INDEX IF NOT EXISTS STOPS_stop_loc_gist ON stops USING gist (stop_loc);
+
+-- Backs ArrivalTimes: stop_times filtered by stop_id (723K rows otherwise seq-scanned)
+CREATE INDEX IF NOT EXISTS STOP_TIMES_stop_id_arrival_time ON stop_times(stop_id, arrival_time);


### PR DESCRIPTION
## Summary
Follow-up from the Postgres feature review:

- **`stops.stop_loc` GIST index** — PostGIS functions were in use but no spatial index existed; every `nearByStops` bbox query was a sequential scan
- **`stop_times(stop_id, arrival_time)`** — `ArrivalTimes` (every stop page, only 15s edge TTL) filters 723K rows by `stop_id`, which no index led with
- **`indexes.sql` is now idempotent and applied even when the reload is skipped** for an unchanged feed — the same class of gap that broke fuzzy search on deploy (extensions.sql lesson), closed for indexes too

## Test plan
- [x] `EXPLAIN` on local DB (full dataset): bbox query → Bitmap Index Scan on `stops_stop_loc_gist`; stop_times query → bitmap scan on the new stop_id index
- [x] indexes.sql applied twice locally — idempotent (creates, then "already exists" notices)
- [x] Backend 81/81 unit + 32/32 integration tests pass; Black clean
- [ ] After merge: dispatch `updateGTFS` — the skip branch now applies the new indexes to prod immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2