### PR TITLE
Auto-run GTFS database update when etl/ changes merge to main

### DIFF
--- a/.github/workflows/updateGTFS.yml
+++ b/.github/workflows/updateGTFS.yml
@@ -1,10 +1,23 @@
-name: Update GTFS database on a CRON Schedule
+name: Update GTFS database
 
 on:
   schedule:
     # Runs "At 00:00." (see https://crontab.guru)
     - cron: "0 0 * * *"
   workflow_dispatch:
+  # Database-affecting changes (schema, extensions, indexes, loader) apply
+  # automatically on merge. When the feed is unchanged the run is cheap:
+  # extensions and indexes are ensured idempotently and the reload is
+  # skipped, so no manual workflow dispatch is needed after such merges.
+  push:
+    branches: [main]
+    paths:
+      - "etl/**"
+
+# Never run two database loads at once (e.g. a merge landing at midnight)
+concurrency:
+  group: update-gtfs
+  cancel-in-progress: false
 
 jobs:
   upload:


### PR DESCRIPTION
## Summary
Removes the manual `updateGTFS` dispatch after DB-affecting merges: the workflow now also triggers on pushes to `main` that touch `etl/**`. With the feed unchanged, a run is cheap and does exactly the right thing — `extensions.sql` (and, once #168 lands, `indexes.sql`) apply idempotently before the reload is skipped.

Also adds a `concurrency` group so a merge-triggered run can't overlap the midnight cron (queued, not cancelled), and drops "on a CRON Schedule" from the workflow name since that's no longer the only trigger.

Note on ordering with backend deploys: a PR touching both `server/` and `etl/` (like the fuzzy-search one) now kicks off both workflows at merge time — the DB step typically completes inside the backend's ~5-minute image build, which is the same ordering we previously orchestrated by hand.

## Test plan
- [x] YAML validates
- [ ] After merge: merging #168 (touches `etl/`) should auto-trigger this workflow and apply the new indexes to prod with no manual dispatch — a live test of the whole mechanism

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2