### PR TITLE
Remove legacy /graphql passthrough from edge cache worker

### DIFF
--- a/workers/graphql-edge-cache/src/index.ts
+++ b/workers/graphql-edge-cache/src/index.ts
@@ -9,9 +9,6 @@
  *
  * - `X-Edge-Cache: HIT | MISS | BYPASS` reports what happened.
  * - Non-200 responses are never cached.
- * - A legacy POST /graphql passthrough remains (BYPASS, no caching) so this
- *   worker can deploy before or after the backend/frontend during the
- *   GraphQL-to-REST rollout; it will be removed in a follow-up.
  *
  * All data served by the backend is public and identical for every user,
  * which is what makes shared caching safe here.
@@ -80,14 +77,11 @@ export default {
     const url = new URL(request.url);
     const upstreamUrl = new URL(url.pathname + url.search, env.UPSTREAM_ORIGIN);
 
-    // Legacy GraphQL passthrough during the REST rollout (no caching)
     if (request.method !== "GET") {
-      const upstream = await fetch(upstreamUrl.toString(), {
-        method: request.method,
-        headers: { "Content-Type": "application/json" },
-        body: await request.text(),
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: CORS_HEADERS,
       });
-      return withEdgeCacheHeaders(upstream, "BYPASS");
     }
 
     const ttl = ttlForPath(url.pathname);


### PR DESCRIPTION
Follow-up to #171. The REST frontend and backend are confirmed live in production, and the backend no longer serves `/graphql`, so the rollout passthrough only forwarded POSTs to a 404. Non-GET requests now get a 405 directly at the edge.

Needs a manual `wrangler deploy` after merge (worker deploys are not in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2