### PR TITLE
Upgrade Postgres 14 → 18 + index/stats tuning for GTFS queries

### DIFF
--- a/docker/compose.db.yml
+++ b/docker/compose.db.yml
@@ -2,7 +2,17 @@ name: austinbusgo
 
 services:
   postgres:
-    image: postgis/postgis:14-3.3
+    image: postgis/postgis:18-3.6
+    # PostGIS publishes only amd64 for PG18; run under emulation on arm64
+    # (the previous 14-3.3 image was amd64-only too, so this is unchanged).
+    platform: linux/amd64
+    # Preload pg_stat_statements so it can track query stats (the extension
+    # is created in etl/sql/extensions.sql). Required in addition to
+    # CREATE EXTENSION — the library must be loaded at server start.
+    command:
+      - postgres
+      - -c
+      - shared_preload_libraries=pg_stat_statements
     restart: always
     environment:
       - POSTGRES_USER=local-user
@@ -16,4 +26,3 @@ services:
       - '5438:5432'
     volumes:
       - ../etl/capmetro:/capmetro
-      - ../server/database/schema.sql:/docker-entrypoint-initdb.d/create_tables.sql

--- a/etl/sql/extensions.sql
+++ b/etl/sql/extensions.sql
@@ -4,3 +4,7 @@
 -- CapMetro to publish a new feed.
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
+-- Query performance monitoring. Requires pg_stat_statements in
+-- shared_preload_libraries (set in docker/compose.db.yml locally; enable the
+-- equivalent flag on the managed instance in production).
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;

--- a/etl/sql/indexes.sql
+++ b/etl/sql/indexes.sql
@@ -7,9 +7,21 @@
 -- added indexes reach the database without waiting for a new feed.
 
 CREATE INDEX IF NOT EXISTS SHAPES_shape_id ON shapes(shape_id);
-CREATE INDEX IF NOT EXISTS TRIPS_trip_id_route_id ON trips(trip_id, route_id);
-CREATE INDEX IF NOT EXISTS TRIPS_trip_id_direction_id ON trips(trip_id, direction_id);
-CREATE INDEX IF NOT EXISTS STOP_TIMES_trip_id ON stop_times(trip_id);
+
+-- trips.trip_id and stops.stop_id are PRIMARY KEYs, so their implicit unique
+-- indexes already serve trip_id / stop_id lookups. These older composites were
+-- redundant: TRIPS_trip_id_* duplicate the trip_id PK (unique -> one row, so the
+-- trailing column adds nothing), and STOP_TIMES_trip_id is a strict prefix of
+-- STOP_TIMES_trip_id_stop_id. Dropped here (idempotent no-ops once gone).
+DROP INDEX IF EXISTS TRIPS_trip_id_route_id;
+DROP INDEX IF EXISTS TRIPS_trip_id_direction_id;
+DROP INDEX IF EXISTS STOP_TIMES_trip_id;
+
+-- The route/direction filters (get_stops_by_route_id, get_trips_by_distinct_
+-- short_name, get_trips_with_direction_and_route) had no supporting index and
+-- fell back to scanning trips. This index covers them directly.
+CREATE INDEX IF NOT EXISTS TRIPS_route_id_direction_id ON trips(route_id, direction_id);
+
 CREATE INDEX IF NOT EXISTS STOP_TIMES_trip_id_stop_id ON stop_times(trip_id, stop_id);
 CREATE INDEX IF NOT EXISTS ROUTES_AT_STOP_stop_id_route_id ON routes_at_stop(stop_id, route_id);
 CREATE INDEX IF NOT EXISTS TRANSFERS_from_stop_id_to_stop_id ON transfers(from_stop_id, to_stop_id);
@@ -23,5 +35,12 @@ CREATE INDEX IF NOT EXISTS ROUTES_route_long_name_trgm ON routes USING gin (rout
 -- Spatial index backing nearByStops' ST_Intersects/ST_Distance
 CREATE INDEX IF NOT EXISTS STOPS_stop_loc_gist ON stops USING gist (stop_loc);
 
--- Backs ArrivalTimes: stop_times filtered by stop_id (723K rows otherwise seq-scanned)
-CREATE INDEX IF NOT EXISTS STOP_TIMES_stop_id_arrival_time ON stop_times(stop_id, arrival_time);
+-- Backs ArrivalTimes: stop_times filtered by (stop_id, arrival_time). The
+-- INCLUDE columns are the remaining stop_times columns that query reads
+-- (get_stop_times_by_stop_id), making it an index-only scan — the covering
+-- index plus the VACUUM ANALYZE in load.sql (which sets the visibility map)
+-- lets Postgres skip the heap entirely. Supersedes the old non-covering index.
+DROP INDEX IF EXISTS STOP_TIMES_stop_id_arrival_time;
+CREATE INDEX IF NOT EXISTS STOP_TIMES_stop_id_arrival_time_covering
+  ON stop_times(stop_id, arrival_time)
+  INCLUDE (trip_id, departure_time, stop_sequence);

--- a/etl/sql/load.sql
+++ b/etl/sql/load.sql
@@ -8,3 +8,9 @@
 \copy calendar_dates from './capmetro/calendar_dates.txt' with csv header
 \copy transfers from './capmetro/transfers.txt' with csv header
 REFRESH MATERIALIZED VIEW routes_at_stop;
+
+-- Refresh planner statistics after the bulk load so query plans are accurate
+-- immediately (instead of waiting for autovacuum), and set the visibility map
+-- so the covering indexes can serve index-only scans. Must run outside a
+-- transaction block (load_db.py invokes psql without --single-transaction).
+VACUUM ANALYZE;

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -1,7 +1,7 @@
 """
 Shared fixtures for integration tests.
 
-Spins up a real PostGIS container (postgis/postgis:14-3.3, matching the
+Spins up a real PostGIS container (postgis/postgis:18-3.6, matching the
 docker-compose setup) and initialises it with the GTFS schema from
 etl/sql/schema.sql so tests exercise the full database stack.
 """
@@ -27,7 +27,7 @@ _SCHEMA_SQL = (Path(__file__).parent.parent / "etl" / "sql" / "schema.sql").read
 @pytest.fixture(scope="session")
 def postgres_container():
     """Start a PostGIS container and keep it running for the entire session."""
-    with PostgresContainer("postgis/postgis:14-3.3") as container:
+    with PostgresContainer("postgis/postgis:18-3.6") as container:
         yield container
 
 


### PR DESCRIPTION
## Summary

Upgrades the database from **PostgreSQL 14 → 18** and applies the query-performance improvements from our discussion. Verified end-to-end on **PG 18.4**.

## Changes

**Version**
- Local image `postgis/postgis:14-3.3` → `18-3.6`. PostGIS only publishes amd64 for PG18, so `platform: linux/amd64` is pinned — but the old `14-3.3` image was amd64-only too, so nothing changes about the local emulation story.
- Removed a dead compose volume mount (`server/database/schema.sql` doesn't exist; the ETL is the schema source).

**Query performance** (all in the ETL SQL, so they reach prod on the next GTFS load)
- **`pg_stat_statements`** — added to `shared_preload_libraries` + `CREATE EXTENSION`, so slow GTFS queries can actually be measured.
- **`VACUUM ANALYZE` at the end of the load** — refreshes planner stats immediately after the bulk load (no waiting on autovacuum) and sets the visibility map that makes index-only scans possible.
- **Covering index** for the hot arrival-times query: `stop_times(stop_id, arrival_time) INCLUDE (trip_id, departure_time, stop_sequence)`. `EXPLAIN` confirms **Index Only Scan, `Heap Fetches: 0`**.
- **Index cleanup** — dropped `TRIPS_trip_id_route_id`, `TRIPS_trip_id_direction_id` (redundant with the unique `trip_id` PK) and `STOP_TIMES_trip_id` (prefix of `trip_id_stop_id`); added `trips(route_id, direction_id)`, which the route/direction filters (`get_stops_by_route_id`, etc.) previously had **no** supporting index for. Net: fewer, better-targeted indexes.

## Verification (local, PG 18.4)

- ETL loads clean (21,787 trips / 761k stop_times / 2,343 stops).
- Extensions present: postgis, pg_trgm, **pg_stat_statements** (and confirmed tracking).
- Arrivals query → **Index Only Scan** on the covering index, `Heap Fetches: 0`, ~2 ms.
- API smoke test all green: `routes`, `stops/nearby` (PostGIS spatial), `search` (pg_trgm fuzzy), `arrival-times` (covering index), `routes/{id}/stops-and-shapes`.

## ⚠️ Production follow-up (not in this PR — needs your GCP access)

1. **Upgrade the Cloud SQL instance to PG 18** — in-place major-version upgrade, or recreate the instance (the DB is fully rebuildable from GTFS via the ETL, so data loss isn't a risk).
2. **Ensure `pg_stat_statements` is in the instance's `shared_preload_libraries`** (Cloud SQL database flag). `CREATE EXTENSION` already runs via `extensions.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSEDVTFPipCJsbTcxYDrt2